### PR TITLE
TGTADM: Allow creating CD/DVD devices that do not have a backingstore

### DIFF
--- a/usr/tgtadm.c
+++ b/usr/tgtadm.c
@@ -779,7 +779,7 @@ int main(int argc, char **argv)
 					  "allowed/supported\n", rc);
 				exit(EINVAL);
 			}
-			if (!path) {
+			if (!path && dev_type != TYPE_MMC) {
 				eprintf("'backing-store' option "
 						"is necessary\n");
 				exit(EINVAL);


### PR DESCRIPTION
Hi,

Please pull this patch that changes tgtadm to allow to create a MMC device without a backing store.
(== no media loaded)

This is useful for cases where you want to load the media at a later stage, or for example for jukeboxes where you would initially create them with the drive being empty. But with all the medial pre-loaded into the storage elements/slots.

regards
ronnie sahlberg
