### PR TITLE
initscript needs bash

### DIFF
--- a/scripts/initd.sample
+++ b/scripts/initd.sample
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This is an example init.d script for stopping/starting/reconfiguring tgtd.
 
 # chkconfig: 345 20 80


### PR DESCRIPTION
Changed initscript to use bash,
to work correctly on e.g. Debian which uses dash by default.
