### PR TITLE
systemd notification support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ export VERSION PREFIX
 export ISCSI_RDMA
 export CEPH_RBD
 export GLFS_BD
+export SD_NOTIFY
 
 .PHONY: all
 all: programs doc conf scripts

--- a/usr/Makefile
+++ b/usr/Makefile
@@ -21,6 +21,10 @@ ifneq ($(GLFS_BD),)
 MODULES += bs_glfs.so
 endif
 
+ifneq ($(SD_NOTIFY),)
+CFLAGS += -DUSE_SYSTEMD
+endif
+
 ifneq ($(shell test -e /usr/include/sys/eventfd.h && test -e /usr/include/libaio.h && echo 1),)
 CFLAGS += -DUSE_EVENTFD
 TGTD_OBJS += bs_aio.o
@@ -46,6 +50,10 @@ CFLAGS += -DTGT_VERSION=\"$(VERSION)$(EXTRAVERSION)\"
 CFLAGS += -DBSDIR=\"$(DESTDIR)$(libdir)/backing-store\"
 
 LIBS += -lpthread -ldl
+
+ifneq ($(SD_NOTIFY),)
+LIBS += -lsystemd-daemon
+endif
 
 PROGRAMS += tgtd tgtadm tgtimg
 TGTD_OBJS += tgtd.o mgmt.o target.o scsi.o log.o driver.o util.o work.o \

--- a/usr/tgtd.c
+++ b/usr/tgtd.c
@@ -617,6 +617,10 @@ int main(int argc, char **argv)
 
 	bs_init();
 
+#ifdef USE_SYSTEMD
+	sd_notify(0, "READY=1\nSTATUS=Starting event loop...");
+#endif
+
 	event_loop();
 
 	lld_exit();

--- a/usr/tgtd.h
+++ b/usr/tgtd.h
@@ -5,6 +5,10 @@
 #include "scsi_cmnd.h"
 #include "tgtadm_error.h"
 
+#ifdef USE_SYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
 struct concat_buf;
 
 #define NR_SCSI_OPCODES		256


### PR DESCRIPTION
tgtd may take some time to initialize before accepting management
commands. Since management commands are used to bring the targets up
during service startup, we have to make sure that tgtd is responsive
before proceeding. To this end, we add a call to sd_notify(3) right
before entering the event loop to signal systemd (if applicable) that
the main process is ready.

Systemd support with the relevant includes and linker flags is optional,
controlled by the SD_NOTIFY make flag.

Signed-off-by: Apollon Oikonomopoulos apoikos@debian.org
