### PR TITLE
fix shmat() return value check bug

### DIFF
--- a/usr/log.c
+++ b/usr/log.c
@@ -79,7 +79,7 @@ static int logarea_init (int size)
 	}
 
 	la->start = shmat(shmid, NULL, 0);
-	if (!la->start) {
+	if (((void *) -1) == la->start) {
 		syslog(LOG_ERR, "shmat msg failed %d", errno);
 		shmdt(la);
 		return 1;
@@ -101,7 +101,7 @@ static int logarea_init (int size)
 		return 1;
 	}
 	la->buff = shmat(shmid, NULL, 0);
-	if (!la->buff) {
+	if (((void *) -1) == la->buff) {
 		syslog(LOG_ERR, "shmat logmsgfailed %d", errno);
 		shmdt(la->start);
 		shmdt(la);


### PR DESCRIPTION
On success shmat() returns the address of the attached shared memory segment; on error (void *) -1 is returned, and errno is set to indicate the cause of the error.
