### PR TITLE
fix tgt-admin to create sheepdog target

### DIFF
--- a/scripts/tgt-admin
+++ b/scripts/tgt-admin
@@ -483,12 +483,12 @@ sub add_backing_direct {
 
 	# Is the device in use?
 	my $can_alloc = 1;
-	if ($bstype !~ "rbd" && $force != 1 && $$target_options_ref{'allow-in-use'} ne "yes") {
+	if ($bstype !~ "rbd" && $bstype !~ "sheepdog" && $force != 1 && $$target_options_ref{'allow-in-use'} ne "yes") {
 		$can_alloc = check_device($backing_store,$data_key_ref);
 	}
 
 	if ($can_alloc == 1 &&
-	   ($bstype =~ "rbd" || (-e $backing_store && ! -d $backing_store))) {
+	   ($bstype =~ "rbd" || $bstype =~ "sheepdog" || (-e $backing_store && ! -d $backing_store))) {
 		my @exec_commands;
 		my $device_type;
 		my $bs_type;


### PR DESCRIPTION
In original implementation, if we've set targets.conf to create targets with Sheepdog, we always saw the error messages such as "# unix:/var/lib/sheepdog/sock:hoge does not exist - please check the configuration file".

This is due to checking the existence of backing-store's file, except RBD.
If we want to use Sheepdog as backing-store, we'll set the untypical string(this is NOT filesystem's path) to the backing-store's path such as "unix:path_of_unix_domain_socket:vdi" or "tcp:host:port:vdi". therefore the backing-store's file is always not exist on filesystem.

This patch works to skip checking the existence of backing-store's file if bs-type is sheepdog. thereby we were succeed in creating targets with Sheepdog.
