### PR TITLE
usr/libssc: Include fcntl.h for loff_t

### DIFF
--- a/usr/libssc.c
+++ b/usr/libssc.c
@@ -19,6 +19,7 @@
  * 02110-1301 USA
  */
 
+#include <fcntl.h>
 #include <stdint.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
Fixes build with musl libc

See also https://github.com/openwrt/packages/pull/1427

Signed-off-by: Karl Palsson <karlp@tweak.net.au>