### PR TITLE
Allow OPTFLAGS to override default CFLAGS

### DIFF
--- a/usr/Makefile
+++ b/usr/Makefile
@@ -40,12 +40,15 @@ INCLUDES += -I.
 
 CFLAGS += -D_GNU_SOURCE
 CFLAGS += $(INCLUDES)
+ifneq ($(OPTFLAGS),)
+CFLAGS += $(OPTFLAGS)
 ifneq ($(DEBUG),)
 CFLAGS += -g -O0 -ggdb -rdynamic
 else
 CFLAGS += -g -O2 -fno-strict-aliasing
 endif
 CFLAGS += -Wall -Wstrict-prototypes -fPIC
+endif
 CFLAGS += -DTGT_VERSION=\"$(VERSION)$(EXTRAVERSION)\"
 CFLAGS += -DBSDIR=\"$(DESTDIR)$(libdir)/backing-store\"
 


### PR DESCRIPTION
When building a package the build system might be wanting to
pass in some additional CFLAGS. So allow for the OPTFLAGS setting
to override the default CFLAGS.