### PR TITLE
tgtd: oom_adjust don't fail on EACCES error

### DIFF
--- a/usr/tgtd.c
+++ b/usr/tgtd.c
@@ -604,7 +604,7 @@ int main(int argc, char **argv)
 	}
 
 	err = oom_adjust();
-	if (err && getuid() == 0)
+	if (err && (errno != EACCES) && getuid() == 0)
 		exit(1);
 
 	err = nr_file_adjust();


### PR DESCRIPTION
When running root-under-userns, don't error out when
attempting to modify oom_score_adj.

Closes: https://bugs.launchpad.net/ubuntu/+source/tgt/+bug/1518440

Signed-off-by: Ryan Harper <ryan.harper@canonical.com>