### PR TITLE
fix errno check

### DIFF
--- a/usr/util.h
+++ b/usr/util.h
@@ -148,7 +148,7 @@ struct signalfd_siginfo {
 	unsigned long long ull_val;     		\
 	ull_val = strtoull(str, &ptr, 0);       	\
 	val = (typeof(val)) ull_val;    		\
-	if (errno || ptr == str)			\
+	if (ull_val == ULONG_MAX || ptr == str)		\
 		ret = EINVAL;   			\
 	else if (val != ull_val)			\
 		ret = ERANGE;   			\


### PR DESCRIPTION
errno can only be checked if the return value indicates an error.
The result of this bug is the following:

 ./tgtd -d 1
-d argument value '1' invalid
Try `tgtd --help' for more information.

As can be seen, it rejects the valid parameter because errno just
happens to be non-zero.