### PR TITLE
Call tgt_event_del before closing the eventfd

### DIFF
--- a/usr/bs_aio.c
+++ b/usr/bs_aio.c
@@ -407,6 +407,7 @@ static void bs_aio_exit(struct scsi_lu *lu)
 {
 	struct bs_aio_info *info = BS_AIO_I(lu);
 
+	tgt_event_del(info->evt_fd);
 	close(info->evt_fd);
 	io_destroy(info->ctx);
 }


### PR DESCRIPTION
If we close fd without removing it from the epoll set, kernel's doing it for us, but it doesn't remove an associated userspace data structure from tgt_events_list. The latter is staying on the list with the (now-)stale fd.

Each deletion of a bs_aio LUN leaves a stale event on tgt_event_list, that can cause slowdown on epoll fd lookups (and it doesn't normally cause invalid userdata access only due to the stack-like nature of tgt_event_list: recently added events getting into the head).

That's why tgt_event_del should be always called before close() if tgt_event_add was called on the fd earlier. I'm considering also making tgt_event_add check and warn(err) for duplicate fds (which are probably stale fds): It would provide at least some means of event_data leak detection in cases when it matters most. 