### PR TITLE
Fix iscsi-tcp unsolicited NOP-IN (ping) task leak

### DIFF
--- a/usr/iscsi/conn.c
+++ b/usr/iscsi/conn.c
@@ -151,6 +151,22 @@ void conn_close(struct iscsi_connection *conn)
 			else
 				iscsi_free_task(task);
 			break;
+		case ISCSI_OP_NOOP_IN:
+			/* NOOP_IN req is allocated within iscsi_tcp
+			 * by a direct call to the transport
+			 * allocation routine, unaccounted in the
+			 * connection refcount and not added to
+			 * task_list, hence it should be freed when
+			 * it's done by a similar direct call.
+			 *
+			 * We're overprotective here by checking tp's
+			 * free_task pointer, avoiding interference
+			 * with iser (I'm unsure if it's relevant
+			 * though).
+			 */
+			if (task->conn->tp->free_task)
+				task->conn->tp->free_task(task);
+			break;
 		case ISCSI_OP_NOOP_OUT:
 		case ISCSI_OP_LOGOUT:
 		case ISCSI_OP_SCSI_TMFUNC:

--- a/usr/iscsi/iscsid.c
+++ b/usr/iscsi/iscsid.c
@@ -1966,6 +1966,22 @@ static int iscsi_task_tx_done(struct iscsi_connection *conn)
 	case ISCSI_OP_SCSI_CMD:
 		err = iscsi_scsi_cmd_tx_done(conn);
 		break;
+	case ISCSI_OP_NOOP_IN:
+		/* NOOP_IN req is allocated within iscsi_tcp
+		 * by a direct call to the transport
+		 * allocation routine, unaccounted in the
+		 * connection refcount and not added to
+		 * task_list, hence it should be freed when
+		 * it's done by a similar direct call.
+		 *
+		 * We're overprotective here by checking tp's
+		 * free_task pointer, avoiding interference
+		 * with iser (I'm unsure if it's relevant
+		 * though).
+		 */
+		if (task->conn->tp->free_task)
+			task->conn->tp->free_task(task);
+		break;
 	case ISCSI_OP_NOOP_OUT:
 	case ISCSI_OP_LOGOUT:
 	case ISCSI_OP_SCSI_TMFUNC:


### PR DESCRIPTION
When an iscsi(tcp) transport is used, and nop_interval/nop_count are set, there's a memory leak of one allocated task for each nop_interval seconds.

As of this pull request, I'm unsure whether my way to fix the problem is worth taking into tgtd upstream, but its other intent of illustrating the problem, making other developers aware of it, probably isn't hampered by my code style.

Details: iscsi_send_ping_nop_in allocates a task that is never freed.
It doesn't affect connection refcount and also doesn't show up in connection's task_list after completion, because allocation is done with a direct call to iscsi_tcp_alloc_task, not the iscsid's iscsi_alloc_tasks, thus bypassing task_list management AND connection refcounting.

I've added tp->free_task calls in two appropriate places (one of them, in iscsid.c, is currently making tgtd eat memory regularly on idle connections with non-zero nop_interval; another one is needed if tgtd disconnects with non-empty tx_clist including nop-in task, that doesn't happen frequently). It's an equivalent of calling iscsi_tcp_free_task directly for a tcp task->conn.

