### PR TITLE
fix missing block_size

### DIFF
--- a/scripts/tgt-setup-lun
+++ b/scripts/tgt-setup-lun
@@ -281,7 +281,10 @@ if [ $bs_type ]; then
 	echo "Setting backing store type: $bs_type"
 	bs_opt="-E $bs_type"
 fi
-$TGTADM --lld $lld_name --op new --mode logicalunit --tid $tid --lun $lun --blocksize $block_size -b $dev $bs_opt
+if [ $block_size ]; then
+  blksz_opt="--blocksize $block_size"
+fi
+$TGTADM --lld $lld_name --op new --mode logicalunit --tid $tid --lun $lun $blksz_opt -b $dev $bs_opt
 res=$?
 
 if [ $res -ne 0 ]; then


### PR DESCRIPTION
If user does not provide a -B parameter, the generated command will be "--blocksize -b <devtype>"
