### PR TITLE
Unlink task from c_hlist before free if needed

### DIFF
--- a/usr/iscsi/iscsid.c
+++ b/usr/iscsi/iscsid.c
@@ -1227,6 +1227,11 @@ void iscsi_free_task(struct iscsi_task *task)
 
 	list_del(&task->c_siblings);
 
+	if (task->c_hlist.prev && task->c_hlist.next
+	    && !list_empty(&task->c_hlist)) {
+		list_del(&task->c_hlist);
+	}
+
 	conn->tp->free_data_buf(conn, scsi_get_in_buffer(&task->scmd));
 	conn->tp->free_data_buf(conn, scsi_get_out_buffer(&task->scmd));
 


### PR DESCRIPTION
Sometimes task is freed (apparently in conn_close) by iscsi_free_task while being linked to a session->cmd_list (where iscsi_free_cmd_task should be appropriate). It may cause use-after-free on later cmd_list traversals.

See stgt mailing list for proposed patches (Fx Cheng has noticed the same problem recently and submitted another possible solution). This pull request reflects my idea on fixing it, not necessarily the best one possible.

I suspect it's conn->rx_task freed in conn_close, which should be checked for opcode the same way it's done during conn->tx_clist traversal. If so, more precise fix would be adding a similar switch(op) to the code freeing the rx_task.