### PR TITLE
fix build w/newer glibc

### DIFF
--- a/usr/bs_sg.c
+++ b/usr/bs_sg.c
@@ -32,6 +32,7 @@
 #include <linux/fs.h>
 #include <linux/major.h>
 #include <sys/ioctl.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/epoll.h>


### PR DESCRIPTION
Building with newer glibc versions fails like so:
bs_sg.c: In function ‘chk_sg_device’:
bs_sg.c:354:6: error: implicit declaration of function ‘major’ [-Werror=implicit-function-declaration]
  if (major(st.st_rdev) == SCSI_GENERIC_MAJOR)

This is because glibc is dropping the implicit sys/sysmacros.h include
from sys/types.h and making the few projects that need it include it
explicitly.