### PR TITLE
doc: tgtd.8.xml: add reference to targets.conf.5

### DIFF
--- a/doc/tgtd.8.xml
+++ b/doc/tgtd.8.xml
@@ -173,7 +173,7 @@
 
   <refsect1><title>SEE ALSO</title>
     <para>
-      tgtadm(8), tgt-admin(8), tgtimg(8), tgt-setup-lun(8).
+      targets.conf(5), tgtadm(8), tgt-admin(8), tgtimg(8), tgt-setup-lun(8).
       <ulink url="http://stgt.sourceforge.net/"/>
     </para>
   </refsect1>


### PR DESCRIPTION
It is helpful to know targets.conf to understand tgtd.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>