### PR TITLE
Quote $backing_store variable in system(), execute() and backtick-calls

### DIFF
--- a/scripts/tgt-admin
+++ b/scripts/tgt-admin
@@ -585,7 +585,7 @@ sub add_backing_direct {
 			my $sg_readcap;
 			my %direct_params;
 			if ($direct_store == 1) {
-				$sg_inq=`sg_inq $backing_store`;
+				$sg_inq=`sg_inq "$backing_store"`;
 				if ($sg_inq=~m {
 					Vendor\ identification:\s+?(.*?)\n
 					\s+Product\ identification:\s+(.*?)\n
@@ -608,7 +608,7 @@ sub add_backing_direct {
 					}
 				}
 
-				$sg_inq=`sg_inq -p 0xb0 $backing_store`;
+				$sg_inq=`sg_inq -p 0xb0 "$backing_store"`;
 				if ($sg_inq=~m {
 					Optimal\ transfer\ length\ granularity:\s+?(\d+).*?\n
 					\s+Maximum\ transfer\ length:\s+?(\d+).*?\n
@@ -623,7 +623,7 @@ sub add_backing_direct {
 					}
 				}
 
-				$sg_readcap=`sg_readcap -16 $backing_store`;
+				$sg_readcap=`sg_readcap -16 "$backing_store"`;
 				if ($sg_readcap=~ m {
 					Logical\ block\ length=(\d+).*?\n
 					\s+Logical\ blocks\ per\ physical\ block\ exponent=(\d+).*?\n
@@ -725,7 +725,7 @@ sub add_backing_direct {
 		if (length $bsopts) { $bsopts = "--bsopts $bsopts" };
 		if (length $bsoflags) { $bsoflags = "--bsoflags $bsoflags" };
 		if (length $block_size) { $block_size = "--blocksize $block_size" };
-		execute("tgtadm -C $control_port --lld $driver --op new --mode logicalunit --tid $next_tid --lun $lun -b $backing_store $device_type $bs_type $bsopts $bsoflags $block_size");
+		execute("tgtadm -C $control_port --lld $driver --op new --mode logicalunit --tid $next_tid --lun $lun -b \"$backing_store\" $device_type $bs_type $bsopts $bsoflags $block_size");
 
 		# Commands should be executed in order
 		my @execute_last;
@@ -1347,7 +1347,7 @@ sub check_device {
 	# Check if userspace uses this device
 	my $lsof_check = check_exe("lsof");
 	if ($lsof_check ne 1) {
-		system("lsof $backing_store >/dev/null 2>&1");
+		system("lsof \"$backing_store\" >/dev/null 2>&1");
 		my $exit_value  = $? >> 8;
 		if ($exit_value eq 0) {
 			execute("# Device $backing_store is used (already tgtd target?).");


### PR DESCRIPTION
The perl-script "tgt-admin" isn't particularly careful about quoting/escaping the contents of the config file it reads. In particular, if you try to use a backing-store file with a space, it'll fail.

Here's a patch that takes care of the space scenario. I haven't investigated to see if there are any possible security issues related to the way config parameters are read into variables that are then passed to system() and backtick-execution, but it's probably best to avoid this.