### PR TITLE
print the correct size of buffer in error printf

### DIFF
--- a/usr/tgtadm.c
+++ b/usr/tgtadm.c
@@ -44,8 +44,6 @@
 #define NO_LOGGING
 #include "log.h"
 
-#define BUFSIZE 4096
-
 static const char program_name[] = "tgtadm";
 static int debug;
 
@@ -992,7 +990,7 @@ int main(int argc, char **argv)
 			      portalOps);
 
 	if (b.err) {
-		eprintf("BUFSIZE (%d bytes) isn't long enough\n", BUFSIZE);
+		eprintf("BUFSIZE (%zu bytes) isn't long enough\n", b.size + 1);
 		return EINVAL;
 	}
 


### PR DESCRIPTION
Buffer size is stored in struct concat_buf.size field, so use that 
instead of BUFSIZE since buffer size can be more than BUFSIZE.
Also, remove BUFSIZE since its not used anymore.

Signed-off-by: Rohan Puri <rohan.puri15@gmail.com>