### PR TITLE
fix confusing error report of connect

### DIFF
--- a/usr/tgtadm.c
+++ b/usr/tgtadm.c
@@ -317,7 +317,7 @@ static int ipc_mgmt_req(struct tgtadm_req *req, struct concat_buf *b)
 	req->len = sizeof(*req) + b->size;
 
 	err = ipc_mgmt_connect(&fd);
-	if (err < 0) {
+	if (err != 0) {
 		eprintf("can't connect to tgt daemon, %m\n");
 		goto out;
 	}


### PR DESCRIPTION
There is a confusing error message when failed to connect to tgtd unix domain socket, it could not check the error, 
instead, it just continue to call write, which in turn cause error `failed to send request hdr to tgt daemon, Transport endpoint is not connected`.

```
	err = ipc_mgmt_connect(&fd);
	if (err < 0) {
```

When ipc_mgmt_connect failed, it returns errno as err, so the err will be a positive value, so when error happens, this check does not works.

```
		eprintf("can't connect to tgt daemon, %m\n");
		goto out;
	}

	err = write(fd, req, sizeof(*req));
```

In fact, it should report error when connect: `can't connect to tgt daemon, THE REAL REASON`