### PR TITLE
tgt-admin: Fix breakage of allowing whole subnets in ACL

### DIFF
--- a/scripts/tgt-admin
+++ b/scripts/tgt-admin
@@ -953,7 +953,7 @@ sub dump_config {
 		if (scalar(@acl_information) != 1 || $acl_information[0] ne "ALL") {
 			foreach my $ini_address (@acl_information) {
 				# determine here if acl is an IP or IQN
-				if ( $ini_address =~ /^[0-9,.E]+$/ ) {
+				if ( $ini_address =~ /^[0-9,.E\/]+$/ ) {
 					print "\tinitiator-address $ini_address\n";
 				} else {
 					print "\tinitiator-name $ini_address\n";


### PR DESCRIPTION
For example, the ACL address '192.168.1.0/24' would wrongly be
recognized as an initiator-name instead of an initiator-address by
tgt-admin, therefore not allowing access from the subnet when later
updating with tgt-admin. For CIDR notation to work we need to allow
slashes in the IP addresses.

Using slashes in ISCSI target names seems to be invalid.

Signed-off-by: Johan Frimodig <johan@frimodig.com>