### PR TITLE
target: replace bzero with memset

### DIFF
--- a/usr/iscsi/target.c
+++ b/usr/iscsi/target.c
@@ -224,7 +224,7 @@ get_redirect_address(char *callback, char *buffer, int buflen,
 {
 	char *p, *addr, *port;
 
-	bzero(buffer, buflen);
+	memset(buffer, 0, buflen);
 	if (call_program(callback, NULL, NULL, buffer, buflen, 0))
 		return -1;
 


### PR DESCRIPTION
bzero is deprecated and replaced witth memset.