### PR TITLE
Fill COMPARE AND WRITE sense INFORMATION with miscompare offset

### DIFF
--- a/usr/bs_rdwr.c
+++ b/usr/bs_rdwr.c
@@ -122,7 +122,7 @@ static void bs_rdwr_request(struct scsi_cmd *cmd)
 		}
 
 		if (memcmp(scsi_get_out_buffer(cmd), tmpbuf, length)) {
-			uint32_t pos = 0;
+			uint64_t pos = 0;
 			char *spos = scsi_get_out_buffer(cmd);
 			char *dpos = tmpbuf;
 
@@ -135,9 +135,10 @@ static void bs_rdwr_request(struct scsi_cmd *cmd)
 			for (pos = 0; pos < length && *spos++ == *dpos++;
 			     pos++)
 				;
-			cmd_error_sense(cmd, MISCOMPARE,
-					ASC_MISCOMPARE_DURING_VERIFY_OPERATION);
 			free(tmpbuf);
+			scsi_set_result(cmd, SAM_STAT_CHECK_CONDITION);
+			sense_data_build_with_info(cmd, MISCOMPARE,
+				ASC_MISCOMPARE_DURING_VERIFY_OPERATION, pos);
 			break;
 		}
 

--- a/usr/tgtd.h
+++ b/usr/tgtd.h
@@ -331,6 +331,8 @@ extern int lu_prevent_removal(struct scsi_lu *lu);
 extern uint64_t scsi_get_devid(int lid, uint8_t *pdu);
 extern int scsi_cmd_perform(int host_no, struct scsi_cmd *cmd);
 extern void sense_data_build(struct scsi_cmd *cmd, uint8_t key, uint16_t asc);
+extern void sense_data_build_with_info(struct scsi_cmd *cmd, uint8_t key,
+				       uint16_t asc, uint64_t info);
 extern uint64_t scsi_rw_offset(uint8_t *scb);
 extern uint32_t scsi_rw_count(uint8_t *scb);
 extern int scsi_is_io_opcode(unsigned char op);


### PR DESCRIPTION
Tested with 3e24292 ("sbc: disable compare_and_write") reverted, using the libiscsi `CompareAndWrite.MiscompareSense` test submitted via https://github.com/sahlberg/libiscsi/pull/344 .