### PR TITLE
fix bug: target bound initiator-name but client cannot discovery the target device

### DIFF
--- a/usr/iscsi/iscsid.c
+++ b/usr/iscsi/iscsid.c
@@ -531,14 +531,7 @@ static void login_start(struct iscsi_connection *conn)
 			return;
 		}
 
-		if (ip_acl(conn->tid, conn)) {
-			rsp->status_class = ISCSI_STATUS_CLS_INITIATOR_ERR;
-			rsp->status_detail = ISCSI_LOGIN_STATUS_TGT_NOT_FOUND;
-			conn->state = STATE_EXIT;
-			return;
-		}
-
-		if (iqn_acl(conn->tid, conn)) {
+		if (ip_acl(conn->tid, conn) && iqn_acl(conn->tid, conn)) {
 			rsp->status_class = ISCSI_STATUS_CLS_INITIATOR_ERR;
 			rsp->status_detail = ISCSI_LOGIN_STATUS_TGT_NOT_FOUND;
 			conn->state = STATE_EXIT;

--- a/usr/iscsi/target.c
+++ b/usr/iscsi/target.c
@@ -197,25 +197,19 @@ static int iqn_match(struct iscsi_connection *conn, char *name)
 
 int iqn_acl(int tid, struct iscsi_connection *conn)
 {
-	int idx, enable, err;
+	int idx, err;
 	char *name;
 
-	enable = 0;
 	for (idx = 0;; idx++) {
 		name = iqn_acl_get(tid, idx);
 		if (!name)
 			break;
 
-		enable = 1;
 		err = iqn_match(conn, name);
 		if (!err)
 			return 0;
 	}
-
-	if (!enable)
-		return 0;
-	else
-		return -EPERM;
+	return -EPERM;
 }
 
 static int
@@ -352,10 +346,7 @@ void target_list_build(struct iscsi_connection *conn, char *addr, char *name)
 		if (name && strcmp(tgt_targetname(target->tid), name))
 			continue;
 
-		if (ip_acl(target->tid, conn))
-			continue;
-
-		if (iqn_acl(target->tid, conn))
+		if (ip_acl(target->tid, conn) && iqn_acl(target->tid, conn))
 			continue;
 
 		if (isns_scn_access(target->tid, conn->initiator))


### PR DESCRIPTION
fix target bound initiator iqn name but client cannot discovery the target device, this is helpful for acl iqn authentication