### PR TITLE
Remove make clear non-existent directories

### DIFF
--- a/usr/Makefile
+++ b/usr/Makefile
@@ -114,4 +114,4 @@ endif
 
 .PHONY: clean
 clean:
-	rm -f *.[od] *.so $(PROGRAMS) iscsi/*.[od] ibmvio/*.[od] fc/*.[od]
+	rm -f *.[od] *.so $(PROGRAMS) iscsi/*.[od]


### PR DESCRIPTION
On "make clean" makefile try to clean directories usr/ibmvio and usr/fc but his non exist currently.