### PR TITLE
fix use-after-free in iser_conn_free()

### DIFF
--- a/usr/iscsi/iser.c
+++ b/usr/iscsi/iser.c
@@ -1353,8 +1353,8 @@ void iser_conn_free(struct iser_conn *conn)
 		free(conn->self_name);
 
 	conn->h.state = STATE_INIT;
-	free(conn);
 	dprintf("conn:%p freed\n", &conn->h);
+	free(conn);
 }
 
 static void iser_sched_conn_free(struct event_data *evt)


### PR DESCRIPTION
In iser_conn_free() lines 1356-1357:

free(conn);
dprintf("conn:%p freed\n", &conn->h);
	
So we free conn structure, than use it. Obviously should be visa versa.