### PR TITLE
fix: unused function errors

### DIFF
--- a/usr/bs_sheepdog.c
+++ b/usr/bs_sheepdog.c
@@ -294,30 +294,9 @@ struct sheepdog_access_info {
 	pthread_cond_t inflight_list_cond;
 };
 
-static inline int is_data_obj_writeable(struct sheepdog_inode *inode,
-					unsigned int idx)
-{
-	return inode->vdi_id == inode->data_vdi_id[idx];
-}
-
-static inline int is_data_obj(uint64_t oid)
-{
-	return !(VDI_BIT & oid);
-}
-
-static inline uint64_t data_oid_to_idx(uint64_t oid)
-{
-	return oid & (MAX_DATA_OBJS - 1);
-}
-
 static inline uint64_t vid_to_vdi_oid(uint32_t vid)
 {
 	return VDI_BIT | ((uint64_t)vid << VDI_SPACE_SHIFT);
-}
-
-static inline uint64_t vid_to_vmstate_oid(uint32_t vid, uint32_t idx)
-{
-	return VMSTATE_BIT | ((uint64_t)vid << VDI_SPACE_SHIFT) | idx;
 }
 
 static inline uint64_t vid_to_data_oid(uint32_t vid, uint32_t idx)


### PR DESCRIPTION
bs_sheepdog.c:297:19: error: unused function 'is_data_obj_writeable' [-Werror,-Wunused-function] static inline int is_data_obj_writeable(struct sheepdog_inode *inode,
                  ^
bs_sheepdog.c:303:19: error: unused function 'is_data_obj' [-Werror,-Wunused-function] static inline int is_data_obj(uint64_t oid)
                  ^
bs_sheepdog.c:308:24: error: unused function 'data_oid_to_idx' [-Werror,-Wunused-function] static inline uint64_t data_oid_to_idx(uint64_t oid)
                       ^
bs_sheepdog.c:318:24: error: unused function 'vid_to_vmstate_oid' [-Werror,-Wunused-function] static inline uint64_t vid_to_vmstate_oid(uint32_t vid, uint32_t idx)

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>