### PR TITLE
fix posix_fallocate ret check

### DIFF
--- a/usr/tgtimg.c
+++ b/usr/tgtimg.c
@@ -452,8 +452,8 @@ static int sbc_new(int op, char *path, char *capacity, char *media_type, int thi
 				exit(5);
 			}
 		} else {
-			if (posix_fallocate(fd, 0, size*1024*1024LL) == -1) {
-				perror("posix_fallocate failed.");
+			if (posix_fallocate(fd, 0, size*1024*1024LL) != 0) {
+				printf("posix_fallocate failed\n");
 				exit(3);
 			}
 		}


### PR DESCRIPTION
"posix_fallocate() returns zero on success, or an error number on failure. Note that errno is not set."