### PR TITLE
OpenRC  init scripts

### DIFF
--- a/scripts/openrc/tgtd.confd
+++ b/scripts/openrc/tgtd.confd
@@ -1,0 +1,5 @@
+# Here you can specify options that are passed directly to tgt daemon
+#tgtd_opts=""
+
+# Config file for automatic configuration with tgt-admin
+#tgtd_conf="/etc/tgt/targets.conf"

--- a/scripts/openrc/tgtd.initd
+++ b/scripts/openrc/tgtd.initd
@@ -1,0 +1,136 @@
+#!/sbin/openrc-run
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# shellcheck shell=sh
+
+# Default configuration fike
+: "${tgtd_conf:=/etc/tgt/targets.conf}"
+
+pidfile="/var/run/${RC_SVCNAME}.pid"
+command="/usr/sbin/tgtd"
+command_args_background="--pid-file ${pidfile}"
+extra_commands="forcedstop"
+extra_started_commands="forcedreload reload"
+
+depend() {
+	use net
+}
+
+start_post() {
+	# We need to wait for 1 second before do anything with tgtd.
+ 	sleep 1
+  	# Put tgtd into "offline" state until all the targets are configured.
+	# We don't want initiators to (re)connect and fail the connection
+	# if configuration is not ready.
+	tgtadm --op update --mode sys --name State -v offline
+
+	# Configure the targets.
+	if [ ! -r  "${tgtd_conf}" ]; then
+		ewarn "Configuration file '${tgtd_conf}' not found!"
+		ewarn "Leaving ${SVCNAME} running in 'offline' state."
+		eend 0
+	else
+		ebegin "Loading target configuration"
+			tgt-admin --update ALL -c "${tgtd_conf}"
+		    retval=$?
+			if [ $retval -ne 0 ]; then
+				eerror "Could not load configuration!"
+				stop
+				exit $?
+			fi
+		eend $retval
+
+		# Put tgtd into "ready" state.
+		ebegin "Onlining targets. Accepting connections"
+			tgtadm --op update --mode sys --name State -v ready
+		eend $?
+	fi
+}
+
+stop() {
+	ebegin "Stopping ${SVCNAME}"
+		# We need to force shutdown if system is restarting
+		# or shutting down.
+		if [ "$RC_RUNLEVEL" = "shutdown" ] ; then
+		    forcedstop
+		else
+			# Remove all targets. Only remove targets which are not in use.
+			tgt-admin --update ALL -c /dev/null >/dev/null 2>&1
+			retval=$?
+			if [ $retval -eq 107 ] ; then
+			    einfo "tgtd is not running"
+			else
+				# tgtd will exit if all targets were removed.
+				tgtadm --op delete --mode system >/dev/null 2>&1
+				retval=$?
+				if [ $retval -ne 0 ] ; then
+				    eerror "WARNING: Some initiators are still connected - could not stop tgtd"
+				fi
+			fi
+		fi
+	eend $retval
+}
+
+forcedstop() {
+	# NOTE: Forced shutdown of the iscsi target may cause data corruption
+	# for initiators that are connected.
+	ewarn "WARNING: Force-stopping target framework daemon"
+	for i in 5 4 3 2 1; do
+		einfo "Continuing in $i seconds..."
+		sleep 1
+	done
+
+	# Offline everything first. May be needed if we're rebooting, but
+	# expect the initiators to reconnect cleanly when we boot again
+	# (i.e. we don't want them to reconnect to a tgtd which is still
+	# onlineg, but the target is gone).
+	tgtadm --op update --mode sys --name State -v offline >/dev/null 2>&1
+	retval=$?
+	if [ $retval -eq 107 ] ; then
+	    einfo "tgtd is not running"
+	else
+		# Offline all targets
+	    tgt-admin --offline ALL
+
+	    # Remove all targets, even if they are still in use.
+	    tgt-admin --update ALL -c /dev/null -f
+
+	    # tgtd shuts down after all targets are removed.
+	    tgtadm --op delete --mode system
+	    retval=$?
+	    if [ $retval -ne 0 ] ; then
+			eerror "Failed to shutdown tgtd"
+			eend 1
+	    fi
+	fi
+	eend $retval
+}
+
+reload() {
+	ebegin "Updating target framework daemon configuration"
+		# Update configuration for targets. Only targets which
+		# are not in use will be updated.
+		tgt-admin --update ALL -c "${tgtd_conf}" >/dev/null 2>&1
+		retval=$?
+		if [ $retval -eq 107 ]; then
+		    ewarn "WARNING: tgtd is not running"
+		fi
+	eend $retval
+}
+
+forcedreload() {
+	ebegin "Updating target framework daemon configuration"
+		ewarn "WARNING: Force-updating running configuration!"
+		# Update configuration for targets, even those in use.
+		tgt-admin --update ALL -f -c "${tgtd_conf}" >/dev/null 2>&1
+		retval=$?
+		if [ $retval -eq 107 ]; then
+			ewarn "WARNING: tgtd is not running"
+		fi
+	eend $retval
+}
+
+status_post() {
+	einfo "Run 'tgt-admin -s' to see detailed target info."
+}


### PR DESCRIPTION
Init scripts adapted for OpenRC.

I have reworked the init script and adapted it for OpenRC init systems, suitable for distributions like Gentoo and Alpine. 

Changes from the previous `tgtd.init` example are 
- using OpenRC functions where appropriately
- checks for a config file and calls tgt-admin
- if there is no default config file, start tgtd and leave it in `offline` mode.
- handles system reboots and shutdowns as graceful as possible. 
- `shellcheck` was used to check coding style
