### PR TITLE
tgtd.initd: add missing tgt_opts

### DIFF
--- a/scripts/openrc/tgtd.initd
+++ b/scripts/openrc/tgtd.initd
@@ -9,7 +9,7 @@
 
 pidfile="/var/run/${RC_SVCNAME}.pid"
 command="/usr/sbin/tgtd"
-command_args_background="--pid-file ${pidfile}"
+command_args_background="--pid-file ${pidfile} ${tgtd_opts}"
 extra_commands="forcedstop"
 extra_started_commands="forcedreload reload"
 


### PR DESCRIPTION
Add missing `${tgtd_opts}` to `command_args_background`. Without it `tgtd_opts` from `tgtd.confd` are not used.

Related bug report for Gentoo Linux https://bugs.gentoo.org/show_bug.cgi?id=915140
