### PR TITLE
Prevents threads from looping indefinitely

### DIFF
--- a/usr/iscsi/iscsid.c
+++ b/usr/iscsi/iscsid.c
@@ -2235,7 +2235,7 @@ again:
 		if (errno != EINTR && errno != EAGAIN)
 			conn->state = STATE_CLOSE;
 		else if (errno == EINTR || errno == EAGAIN)
-			goto again;
+			conn->tp->ep_event_modify(conn, EPOLLIN | EPOLLOUT);
 
 		return -EIO;
 	}


### PR DESCRIPTION
When the iscsi client is powered off, the tgt socket has not finished sending data in the kernel, and the thread will loop indefinitely