### PR TITLE
util.h - unmap region of block device

### DIFF
--- a/doc/tgtadm.8.xml
+++ b/doc/tgtadm.8.xml
@@ -418,9 +418,14 @@ tgtadm --lld iscsi --mode logicalunit --op update --tid 1 --lun 1 \
 	    This parameter only applies to DISK devices.
           </para>
           <para>
-	    Thin-provisioning only works for LUNs stored on filesystems
+	    Thin-provisioning works for LUNs stored on filesystems
 	    that support FALLOC_FL_PUNCH_HOLE.
           </para>
+	  <para>
+	    When using thin-provisioning option with a block device such a
+	    SSD or ZVOL, UNMAP SCSI command discards the region from
+	    the block device.
+	  </para>
         </listitem>
       </varlistentry>
 

--- a/usr/util.h
+++ b/usr/util.h
@@ -217,14 +217,8 @@ void concat_buf_release(struct concat_buf *b);
  */
 static inline int unmap_file_region(int fd, off_t offset, off_t length)
 {
-	int err;
 	struct stat64 st;
-#ifdef BLKDISCARD
-	uint64_t range[2];
-#endif
-
-	err = fstat64(fd, &st);
-	if (err < 0)
+	if (fstat64(fd, &st) < 0)
 		return -1;
 	if (S_ISREG(st.st_mode)) {
 #ifdef FALLOC_FL_PUNCH_HOLE
@@ -234,8 +228,7 @@ static inline int unmap_file_region(int fd, off_t offset, off_t length)
 #endif
 	} else if (S_ISBLK(st.st_mode)) {
 #ifdef BLKDISCARD
-		range[0] = offset;
-		range[1] = length;
+		uint64_t range[] = { offset, length };
 		if (ioctl(fd, BLKDISCARD, &range) == 0)
 			return 0;
 #endif

--- a/usr/util.h
+++ b/usr/util.h
@@ -16,6 +16,9 @@
 #include <limits.h>
 #include <linux/types.h>
 #include <sys/ioctl.h>
+#include <linux/fs.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 
 #include "be_byteshift.h"
 

--- a/usr/util.h
+++ b/usr/util.h
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <limits.h>
 #include <linux/types.h>
+#include <sys/ioctl.h>
 
 #include "be_byteshift.h"
 
@@ -215,7 +216,9 @@ static inline int unmap_file_region(int fd, off_t offset, off_t length)
 {
 	int err;
 	struct stat64 st;
+#ifdef BLKDISCARD
 	uint64_t range[2];
+#endif
 
 	err = fstat64(fd, &st);
 	if (err < 0)


### PR DESCRIPTION
In RDWR mode, if file is a block device, like a SSD or ZVOL, try to unmap the region on block device, using ioctl BLKDISCARD.