### PR TITLE
Update tgtd.spec

### DIFF
--- a/scripts/tgtd.spec
+++ b/scripts/tgtd.spec
@@ -79,7 +79,7 @@ fi
 
 %files
 %defattr(-, root, root, -)
-%doc README doc/README.iscsi doc/README.iser doc/README.lu_configuration doc/README.mmc
+%doc doc/README.iscsi doc/README.iser doc/README.lu_configuration doc/README.mmc
 %{_sbindir}/tgtd
 %{_sbindir}/tgtadm
 %{_sbindir}/tgt-setup-lun


### PR DESCRIPTION
Hi there,

It looks like you don't have a base README anymore, and with this definition in place, 'make rpm' won't run.

I've suggested pulling that from the spec - maybe there's other definitions as well that need updating, but this is the minimum required for making rpms on EL8.