### PR TITLE
Add io_uring backend

### DIFF
--- a/doc/tgtadm.8.xml
+++ b/doc/tgtadm.8.xml
@@ -106,12 +106,13 @@ Possible device-types are:
       </varlistentry>
       <screen format="linespecific">
 Possible backend types are:
-    rdwr    : Use normal file I/O. This is the default for disk devices
-    aio     : Use Asynchronous I/O
-    rbd     : Use Ceph's distributed-storage RADOS Block Device
+    rdwr     : Use normal file I/O. This is the default for disk devices
+    aio      : Use Asynchronous I/O
+    io_uring : Use io_uring I/O
+    rbd      : Use Ceph's distributed-storage RADOS Block Device
 
-    sg      : Special backend type for passthrough devices
-    ssc     : Special backend type for tape emulation
+    sg       : Special backend type for passthrough devices
+    ssc      : Special backend type for tape emulation
       </screen>
 
       <varlistentry><term><option>--lld &lt;driver&gt; --op new --mode target --tid &lt;id&gt; --targetname &lt;name&gt;</option></term>

--- a/scripts/tgt.bashcomp.sh
+++ b/scripts/tgt.bashcomp.sh
@@ -162,7 +162,7 @@ _tgtadm() {
                 portal pt session sess connection conn account lld" -- "${cur}") )
             return 0;;
         --bstype|-E)
-            COMPREPLY=( $(compgen -W "rdwr aio rbd sg ssc" -- "${cur}") )
+            COMPREPLY=( $(compgen -W "rdwr aio rbd sg ssc io_uring" -- "${cur}") )
             return 0;;
         --bsoflags|-f)
             COMPREPLY=( $(compgen -W "direct sync" -- "${cur}") )

--- a/scripts/tgtd.spec
+++ b/scripts/tgtd.spec
@@ -8,7 +8,7 @@ License:        GPLv2
 URL:            http://stgt.sourceforge.net/
 Source0:        %{name}-%{version}-%{release}.tgz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-BuildRequires:  pkgconfig libibverbs-devel librdmacm-devel libxslt libaio-devel
+BuildRequires:  pkgconfig libibverbs-devel librdmacm-devel libxslt libaio-devel liburing
 %if %{defined suse_version}
 BuildRequires:  docbook-xsl-stylesheets
 Requires: aaa_base

--- a/usr/Makefile
+++ b/usr/Makefile
@@ -31,6 +31,11 @@ TGTD_OBJS += bs_aio.o
 LIBS += -laio
 endif
 
+ifneq ($(shell test -e /usr/include/sys/eventfd.h && test -e /usr/include/liburing.h && echo 1),)
+TGTD_OBJS += bs_io_uring.o
+LIBS += -luring
+endif
+
 ifneq ($(ISCSI_RDMA),)
 TGTD_OBJS += iscsi/iser.o iscsi/iser_text.o
 LIBS += -libverbs -lrdmacm

--- a/usr/bs_io_uring.c
+++ b/usr/bs_io_uring.c
@@ -82,8 +82,7 @@ static void bs_io_uring_get_completions_helper(struct bs_io_uring_info *info)
 	uint64_t evts_complete;
 
 	while (1) {
-		int ret = read(info->evt_fd, &evts_complete,
-			       sizeof(evts_complete));
+		int ret = read(info->evt_fd, &evts_complete, sizeof(evts_complete));
 		if (ret < 0) {
 			switch (errno) {
 			case EINTR:
@@ -101,13 +100,11 @@ static void bs_io_uring_get_completions_helper(struct bs_io_uring_info *info)
 
 	io_uring_for_each_cqe(&info->ring, head, cqe)
 	{
-		struct scsi_cmd *cmd =
-			(struct scsi_cmd *)io_uring_cqe_get_data(cqe);
+		struct scsi_cmd *cmd = (struct scsi_cmd *)io_uring_cqe_get_data(cqe);
 		if (cmd != NULL) {
 			int result = SAM_STAT_GOOD;
 			if (unlikely(cqe->res < 0)) {
-				eprintf("error in async operation: %s\n",
-					strerror(-cqe->res));
+				eprintf("error in async operation: %s\n", strerror(-cqe->res));
 				sense_data_build(cmd, MEDIUM_ERROR, 0);
 				result = SAM_STAT_CHECK_CONDITION;
 			}
@@ -132,8 +129,7 @@ static int queue_read(struct bs_io_uring_info *info, struct scsi_cmd *cmd)
 
 	io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
 	io_uring_sqe_set_data(sqe, cmd);
-	io_uring_prep_read(sqe, 0, scsi_get_in_buffer(cmd),
-			   scsi_get_in_length(cmd), cmd->offset);
+	io_uring_prep_read(sqe, 0, scsi_get_in_buffer(cmd), scsi_get_in_length(cmd), cmd->offset);
 	set_cmd_async(cmd);
 
 	info->npending++;
@@ -151,8 +147,7 @@ static int queue_write(struct bs_io_uring_info *info, struct scsi_cmd *cmd)
 
 	io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
 	io_uring_sqe_set_data(sqe, cmd);
-	io_uring_prep_write(sqe, 0, scsi_get_out_buffer(cmd),
-			    scsi_get_out_length(cmd), cmd->offset);
+	io_uring_prep_write(sqe, 0, scsi_get_out_buffer(cmd), scsi_get_out_length(cmd), cmd->offset);
 	set_cmd_async(cmd);
 
 	info->npending++;
@@ -204,8 +199,7 @@ static int queue_unmap(struct bs_io_uring_info *info, struct scsi_cmd *cmd)
 
 		if (offset + tl > cmd->dev->size) {
 			eprintf("UNMAP beyond EOF\n");
-			cmd_error_sense(cmd, ILLEGAL_REQUEST,
-					ASC_LBA_OUT_OF_RANGE);
+			cmd_error_sense(cmd, ILLEGAL_REQUEST, ASC_LBA_OUT_OF_RANGE);
 			return 0;
 		}
 
@@ -216,8 +210,7 @@ static int queue_unmap(struct bs_io_uring_info *info, struct scsi_cmd *cmd)
 			case UNMAP_MODE_FALLOCATE:
 #ifdef FALLOC_FL_PUNCH_HOLE
 				while (info->npending >= info->iodepth) {
-					bs_io_uring_get_completions_helper(
-						info);
+					bs_io_uring_get_completions_helper(info);
 				}
 				struct io_uring_sqe *sqe;
 				sqe = io_uring_get_sqe(&info->ring);
@@ -231,13 +224,8 @@ static int queue_unmap(struct bs_io_uring_info *info, struct scsi_cmd *cmd)
 					io_uring_sqe_set_data(sqe, NULL);
 					sqe->flags |= IOSQE_IO_LINK;
 				}
-				dprintf("sending fallocate o: %lu l %u\n",
-					offset, tl);
-				io_uring_prep_fallocate(
-					sqe, 0,
-					FALLOC_FL_PUNCH_HOLE |
-						FALLOC_FL_KEEP_SIZE,
-					offset, tl);
+				dprintf("sending fallocate o: %lu l %u\n", offset, tl);
+				io_uring_prep_fallocate(sqe, 0, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, tl);
 				io_uring_submit(&info->ring);
 				info->npending++;
 				set_cmd_async(cmd);
@@ -247,16 +235,11 @@ static int queue_unmap(struct bs_io_uring_info *info, struct scsi_cmd *cmd)
 #ifdef BLKDISCARD
 				// We have to send a sync request here to use ioctl
 				uint64_t range[] = { offset, tl };
-				dprintf("sending BLKDISCARD o: %lu l: %lu\n",
-					range[0], range[1]);
-				int ret =
-					ioctl(cmd->dev->fd, BLKDISCARD, &range);
+				dprintf("sending BLKDISCARD o: %lu l: %lu\n", range[0], range[1]);
+				int ret = ioctl(cmd->dev->fd, BLKDISCARD, &range);
 				if (ret) {
-					eprintf("BLKDISCARD got code %d %s\n",
-						ret, strerror(-ret));
-					cmd_error_sense(
-						cmd, HARDWARE_ERROR,
-						ASC_INTERNAL_TGT_FAILURE);
+					eprintf("BLKDISCARD got code %d %s\n", ret, strerror(-ret));
+					cmd_error_sense(cmd, HARDWARE_ERROR, ASC_INTERNAL_TGT_FAILURE);
 					return ret;
 				}
 #endif
@@ -307,8 +290,7 @@ static int bs_io_uring_cmd_submit(struct scsi_cmd *cmd)
 	case SYNCHRONIZE_CACHE:
 	case SYNCHRONIZE_CACHE_16:
 		if (cmd->scb[1] & 0x2) {
-			cmd_error_sense(cmd, ILLEGAL_REQUEST,
-					ASC_INVALID_FIELD_IN_CDB);
+			cmd_error_sense(cmd, ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
 			ret = -1;
 		} else {
 			ret = queue_sync(info, cmd);
@@ -316,8 +298,7 @@ static int bs_io_uring_cmd_submit(struct scsi_cmd *cmd)
 		break;
 	case UNMAP:
 		if (!cmd->dev->attrs.thinprovisioning) {
-			cmd_error_sense(cmd, ILLEGAL_REQUEST,
-					ASC_INVALID_FIELD_IN_CDB);
+			cmd_error_sense(cmd, ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
 			ret = -1;
 		} else {
 			ret = queue_unmap(info, cmd);
@@ -346,8 +327,7 @@ static void bs_io_uring_get_completions(int fd, int events, void *data)
 	bs_io_uring_get_completions_helper(info);
 }
 
-static int bs_io_uring_open(struct scsi_lu *lu, char *path, int *fd,
-			    uint64_t *size)
+static int bs_io_uring_open(struct scsi_lu *lu, char *path, int *fd, uint64_t *size)
 {
 	struct bs_io_uring_info *info = BS_IO_URING_I(lu);
 	struct io_uring_params params;
@@ -358,9 +338,8 @@ static int bs_io_uring_open(struct scsi_lu *lu, char *path, int *fd,
 	params.flags |= IORING_SETUP_SQPOLL;
 	params.sq_thread_idle = 1000;
 
-	eprintf("create io_uring context for tgt:%d lun:%" PRId64
-		", max iodepth:%d\n",
-		info->lu->tgt->tid, info->lu->lun, info->iodepth);
+	eprintf("create io_uring context for tgt:%d lun:%" PRId64 ", max iodepth:%d\n", info->lu->tgt->tid,
+		info->lu->lun, info->iodepth);
 
 	ret = io_uring_queue_init_params(info->iodepth, &info->ring, &params);
 	if (ret) {
@@ -370,39 +349,32 @@ static int bs_io_uring_open(struct scsi_lu *lu, char *path, int *fd,
 
 	int afd = eventfd(0, O_NONBLOCK);
 	if (afd < 0) {
-		eprintf("failed to create eventfd for tgt:%d lun:%" PRId64
-			", %m\n",
-			info->lu->tgt->tid, info->lu->lun);
+		eprintf("failed to create eventfd for tgt:%d lun:%" PRId64 ", %m\n", info->lu->tgt->tid, info->lu->lun);
 		ret = afd;
 		goto close_ctx;
 	}
-	dprintf("eventfd:%d for tgt:%d lun:%" PRId64 "\n", afd,
-		info->lu->tgt->tid, info->lu->lun);
+	dprintf("eventfd:%d for tgt:%d lun:%" PRId64 "\n", afd, info->lu->tgt->tid, info->lu->lun);
 
 	ret = tgt_event_add(afd, EPOLLIN, bs_io_uring_get_completions, info);
 	if (ret)
 		goto close_eventfd;
 	info->evt_fd = afd;
 
-	eprintf("open %s, RW for tgt:%d lun:%" PRId64 "\n", path,
-		info->lu->tgt->tid, info->lu->lun);
+	eprintf("open %s, RW for tgt:%d lun:%" PRId64 "\n", path, info->lu->tgt->tid, info->lu->lun);
 	*fd = backed_file_open(path, O_RDWR, size, &blksize);
 	/* If we get access denied, try opening the file in readonly mode */
 	if (*fd == -1 && (errno == EACCES || errno == EROFS)) {
-		eprintf("open %s, READONLY for tgt:%d lun:%" PRId64 "\n", path,
-			info->lu->tgt->tid, info->lu->lun);
+		eprintf("open %s, READONLY for tgt:%d lun:%" PRId64 "\n", path, info->lu->tgt->tid, info->lu->lun);
 		*fd = backed_file_open(path, O_RDONLY, size, &blksize);
 		lu->attrs.readonly = 1;
 	}
 	if (*fd < 0) {
-		eprintf("failed to open %s, for tgt:%d lun:%" PRId64 ", %m\n",
-			path, info->lu->tgt->tid, info->lu->lun);
+		eprintf("failed to open %s, for tgt:%d lun:%" PRId64 ", %m\n", path, info->lu->tgt->tid, info->lu->lun);
 		ret = *fd;
 		goto remove_tgt_evt;
 	}
 
-	eprintf("%s opened successfully for tgt:%d lun:%" PRId64 "\n", path,
-		info->lu->tgt->tid, info->lu->lun);
+	eprintf("%s opened successfully for tgt:%d lun:%" PRId64 "\n", path, info->lu->tgt->tid, info->lu->lun);
 
 	struct stat st;
 	if (fstat(*fd, &st) < 0) {

--- a/usr/bs_io_uring.c
+++ b/usr/bs_io_uring.c
@@ -1,5 +1,5 @@
 /*
- * AIO backing store
+ * io_uring backing store
  *
  * Copyright (C) 2024 Jonathan Frederick <doublej472@gmail.com>
  *

--- a/usr/bs_io_uring.c
+++ b/usr/bs_io_uring.c
@@ -1,0 +1,444 @@
+/*
+ * AIO backing store
+ *
+ * Copyright (C) 2024 Jonathan Frederick <doublej472@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, version 2 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+#include <errno.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <linux/fs.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <liburing.h>
+#include <stdlib.h>
+
+#include "list.h"
+#include "util.h"
+#include "tgtd.h"
+#include "target.h"
+#include "scsi.h"
+#include <linux/time_types.h>
+
+#define IO_URING_MAX_IODEPTH 1024
+
+struct bs_io_uring_info {
+	struct io_uring ring;
+	struct scsi_lu *lu;
+	int evt_fd;
+	unsigned int npending;
+	unsigned int iodepth;
+};
+
+static inline struct bs_io_uring_info *BS_IO_URING_I(struct scsi_lu *lu)
+{
+	return (struct bs_io_uring_info *) ((char *)lu + sizeof(*lu));
+}
+
+static void cmd_error_sense(struct scsi_cmd *cmd, uint8_t key, uint16_t asc)
+{
+	scsi_set_result(cmd, SAM_STAT_CHECK_CONDITION);
+	sense_data_build(cmd, key, asc);
+}
+
+static void bs_io_uring_get_completions_helper(struct bs_io_uring_info *info) {
+	// printf("bs_io_uring_get_completions_helper called\n");
+	struct io_uring_cqe *cqe;
+
+	struct __kernel_timespec ts;
+	ts.tv_nsec = 0;
+	ts.tv_sec = 0;
+
+	while (true) {
+		int ret = io_uring_wait_cqe_timeout(&info->ring, &cqe, &ts);
+		if (ret == -ETIME) {
+			return;
+		} else if (ret < 0) {
+            printf("e: error waiting for completion: %s\n", strerror(-ret));
+			break;
+        }
+
+		struct scsi_cmd* cmd = (struct scsi_cmd*) io_uring_cqe_get_data(cqe);
+		int result = SAM_STAT_GOOD;
+
+		if (cqe->res < 0) {
+            printf("e: error in async operation: %s\n", strerror(-cqe->res));
+			sense_data_build(cmd, MEDIUM_ERROR, 0);
+			result = SAM_STAT_CHECK_CONDITION;
+        }
+
+        io_uring_cqe_seen(&info->ring, cqe);
+		target_cmd_io_done(cmd, result);
+		info->npending--;
+	}
+}
+
+static int queue_read(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
+	while (info->npending >= info->iodepth) {
+		bs_io_uring_get_completions_helper(info);
+	}
+	
+	struct io_uring_sqe *sqe;
+	sqe = io_uring_get_sqe(&info->ring);
+    if (!sqe) {
+        return 1;
+    }
+
+	// io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
+	io_uring_sqe_set_data(sqe, cmd);
+	io_uring_prep_read(sqe, cmd->dev->fd, scsi_get_in_buffer(cmd), scsi_get_in_length(cmd), cmd->offset);
+	set_cmd_async(cmd);
+
+	info->npending++;
+	io_uring_submit(&info->ring);
+	return 0;
+}
+
+static int queue_write(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
+	while (info->npending >= info->iodepth) {
+		bs_io_uring_get_completions_helper(info);
+	}
+
+	struct io_uring_sqe *sqe;
+	sqe = io_uring_get_sqe(&info->ring);
+    if (!sqe) {
+        return 1;
+    }
+
+	// io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
+	io_uring_sqe_set_data(sqe, cmd);
+	io_uring_prep_write(sqe, cmd->dev->fd, scsi_get_out_buffer(cmd), scsi_get_out_length(cmd), cmd->offset);
+	set_cmd_async(cmd);
+
+	info->npending++;
+	io_uring_submit(&info->ring);
+	return 0;
+}
+
+static int queue_sync(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
+	while (info->npending >= info->iodepth) {
+		bs_io_uring_get_completions_helper(info);
+	}
+	
+	struct io_uring_sqe *sqe;
+	sqe = io_uring_get_sqe(&info->ring);
+    if (!sqe) {
+        return 1;
+    }
+
+	if (cmd->scb[0] == SYNCHRONIZE_CACHE_16) {
+		sqe->off = cmd->offset;
+		sqe->len =scsi_get_in_length(cmd);
+	}
+	io_uring_sqe_set_data(sqe, cmd);
+	printf("d: fdatasync offset %llu len %u\n", sqe->off, sqe->len);
+	io_uring_prep_fsync(sqe, cmd->dev->fd, IORING_FSYNC_DATASYNC);
+	set_cmd_async(cmd);
+
+	info->npending++;
+	io_uring_submit(&info->ring);
+	return 0;
+}
+
+static int queue_unmap(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
+	uint32_t length = scsi_get_out_length(cmd);
+	char* tmpbuf = scsi_get_out_buffer(cmd);
+
+	if (length < 8)
+		return 0;
+	
+	while (info->npending >= info->iodepth) {
+		bs_io_uring_get_completions_helper(info);
+	}
+	
+	struct io_uring_sqe *sqe;
+	sqe = io_uring_get_sqe(&info->ring);
+    if (!sqe) {
+        return 1;
+    }
+
+	length -= 8;
+	tmpbuf += 8;
+
+	while (length >= 16) {
+		uint64_t offset = get_unaligned_be64(&tmpbuf[0]);
+		offset = offset << cmd->dev->blk_shift;
+
+		uint32_t tl = get_unaligned_be32(&tmpbuf[8]);
+		tl = tl << cmd->dev->blk_shift;
+
+		if (offset + tl > cmd->dev->size) {
+			eprintf("UNMAP beyond EOF\n");
+			cmd_error_sense(cmd, ILLEGAL_REQUEST,
+					ASC_LBA_OUT_OF_RANGE);
+			break;
+		}
+
+		if (tl > 0) {
+			io_uring_sqe_set_data(sqe, cmd);
+			printf("d: unmap offset %lu length %u\n", offset, tl);
+			io_uring_prep_fallocate(sqe, cmd->dev->fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, tl);
+			set_cmd_async(cmd);
+			info->npending++;
+		}
+
+		length -= 16;
+		tmpbuf += 16;
+	}
+
+	io_uring_submit(&info->ring);
+	return 0;
+}
+
+static int bs_io_uring_cmd_submit(struct scsi_cmd *cmd)
+{
+	struct scsi_lu *lu = cmd->dev;
+	struct bs_io_uring_info *info = BS_IO_URING_I(lu);
+	unsigned int scsi_op = (unsigned int)cmd->scb[0];
+	int ret;
+
+	switch (scsi_op) {
+	case WRITE_6:
+	case WRITE_10:
+	case WRITE_12:
+	case WRITE_16:
+		ret = queue_write(info, cmd);
+
+		// printf("d: write offset: %lx\n", cmd->offset);
+		break;
+
+	case READ_6:
+	case READ_10:
+	case READ_12:
+	case READ_16:
+		ret = queue_read(info, cmd);
+
+		// printf("d: read offset: %lx\n", cmd->offset);
+		break;
+	case SYNCHRONIZE_CACHE:
+	case SYNCHRONIZE_CACHE_16:
+		if (cmd->scb[1] & 0x2) {
+			cmd_error_sense(cmd, ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
+			ret = -1;
+		} else {
+			ret = queue_sync(info, cmd);
+		}
+		break;
+	case UNMAP:
+		if (!cmd->dev->attrs.thinprovisioning) {
+			cmd_error_sense(cmd, ILLEGAL_REQUEST,
+					ASC_INVALID_FIELD_IN_CDB);
+			ret = -1;
+			break;
+		}
+		ret = queue_unmap(info, cmd);
+		break;
+	case WRITE_SAME:
+	case WRITE_SAME_16:
+		printf("d: WRITE_SAME not yet supported for IO_URING backend.\n");
+		ret = -1;
+		break;
+
+	default:
+		printf("d: skipped cmd:%p op:%x\n", cmd, scsi_op);
+		ret = 0;
+	}
+
+	return ret;
+}
+
+static void bs_io_uring_get_completions(int fd, int events, void *data)
+{
+	// printf("bs_io_uring_get_completions called\n");
+	struct bs_io_uring_info *info = data;
+	bs_io_uring_get_completions_helper(info);
+}
+
+static int bs_io_uring_open(struct scsi_lu *lu, char *path, int *fd, uint64_t *size)
+{
+	struct bs_io_uring_info *info = BS_IO_URING_I(lu);
+	struct io_uring_params params;
+	int ret, afd;
+	uint32_t blksize = 0;
+
+	memset(&params, 0, sizeof(params));
+	params.flags |= IORING_SETUP_SQPOLL;
+    params.sq_thread_idle = 2000;
+	
+	printf("e: create io_uring context for tgt:%d lun:%"PRId64 ", max iodepth:%d\n",
+		info->lu->tgt->tid, info->lu->lun, info->iodepth);
+
+    ret = io_uring_queue_init_params(info->iodepth, &info->ring, &params);
+    if (ret) {
+		printf("e: failed to init io_uring queue params, %m\n");
+		return ret;
+	}
+
+	afd = eventfd(0, O_NONBLOCK);
+	if (afd < 0) {
+		eprintf("failed to create eventfd for tgt:%d lun:%"PRId64 ", %m\n",
+			info->lu->tgt->tid, info->lu->lun);
+		ret = afd;
+		goto close_ctx;
+	}
+	printf("d: eventfd:%d for tgt:%d lun:%"PRId64 "\n",
+		afd, info->lu->tgt->tid, info->lu->lun);
+
+	ret = tgt_event_add(afd, EPOLLIN, bs_io_uring_get_completions, info);
+	if (ret)
+		goto close_eventfd;
+	info->evt_fd = afd;
+
+	printf("e: open %s, RW for tgt:%d lun:%"PRId64 "\n",
+		path, info->lu->tgt->tid, info->lu->lun);
+	*fd = backed_file_open(path, O_RDWR, size,
+				&blksize);
+	/* If we get access denied, try opening the file in readonly mode */
+	if (*fd == -1 && (errno == EACCES || errno == EROFS)) {
+		printf("e: open %s, READONLY for tgt:%d lun:%"PRId64 "\n",
+			path, info->lu->tgt->tid, info->lu->lun);
+		*fd = backed_file_open(path, O_RDONLY,
+				       size, &blksize);
+		lu->attrs.readonly = 1;
+	}
+	if (*fd < 0) {
+		printf("e: failed to open %s, for tgt:%d lun:%"PRId64 ", %m\n",
+			path, info->lu->tgt->tid, info->lu->lun);
+		ret = *fd;
+		goto remove_tgt_evt;
+	}
+
+	printf("e: %s opened successfully for tgt:%d lun:%"PRId64 "\n",
+		path, info->lu->tgt->tid, info->lu->lun);
+	
+	ret = io_uring_register_files(&info->ring, fd, 1);
+    if(ret) {
+        printf("failed to register buffers: %s\n", strerror(-ret));
+        goto remove_tgt_evt;
+    }
+	ret = io_uring_register_eventfd(&info->ring, info->evt_fd);
+	if(ret) {
+        printf("failed to register eventfd: %s\n", strerror(-ret));
+        goto remove_tgt_evt;
+    }
+
+	if (!lu->attrs.no_auto_lbppbe)
+		update_lbppbe(lu, blksize);
+
+	return 0;
+
+remove_tgt_evt:
+	tgt_event_del(afd);
+close_eventfd:
+	close(afd);
+close_ctx:
+    io_uring_queue_exit(&info->ring);
+	return ret;
+}
+
+static void bs_io_uring_close(struct scsi_lu *lu)
+{
+	close(lu->fd);
+}
+
+static tgtadm_err bs_io_uring_init(struct scsi_lu *lu, char *bsopts)
+{
+	struct bs_io_uring_info *info = BS_IO_URING_I(lu);
+
+	memset(info, 0, sizeof(*info));
+	info->lu = lu;
+	info->iodepth = IO_URING_MAX_IODEPTH;
+
+	return TGTADM_SUCCESS;
+}
+
+static void bs_io_uring_exit(struct scsi_lu *lu)
+{
+	struct bs_io_uring_info *info = BS_IO_URING_I(lu);
+	tgt_event_del(info->evt_fd);
+	close(info->evt_fd);
+    io_uring_queue_exit(&info->ring);
+}
+
+static struct backingstore_template io_uring_bst = {
+	.bs_name		= "io_uring",
+	.bs_datasize    	= sizeof(struct bs_io_uring_info),
+	.bs_init		= bs_io_uring_init,
+	.bs_exit		= bs_io_uring_exit,
+	.bs_open		= bs_io_uring_open,
+	.bs_close       	= bs_io_uring_close,
+	.bs_cmd_submit  	= bs_io_uring_cmd_submit,
+};
+
+__attribute__((constructor)) static void register_bs_module(void)
+{
+	unsigned char opcodes[] = {
+		ALLOW_MEDIUM_REMOVAL,
+		COMPARE_AND_WRITE,
+		FORMAT_UNIT,
+		INQUIRY,
+		MAINT_PROTOCOL_IN,
+		MODE_SELECT,
+		MODE_SELECT_10,
+		MODE_SENSE,
+		MODE_SENSE_10,
+		ORWRITE_16,
+		PERSISTENT_RESERVE_IN,
+		PERSISTENT_RESERVE_OUT,
+		PRE_FETCH_10,
+		PRE_FETCH_16,
+		READ_10,
+		READ_12,
+		READ_16,
+		READ_6,
+		READ_CAPACITY,
+		RELEASE,
+		REPORT_LUNS,
+		REQUEST_SENSE,
+		RESERVE,
+		SEND_DIAGNOSTIC,
+		SERVICE_ACTION_IN,
+		START_STOP,
+		SYNCHRONIZE_CACHE,
+		SYNCHRONIZE_CACHE_16,
+		TEST_UNIT_READY,
+		UNMAP,
+		VERIFY_10,
+		VERIFY_12,
+		VERIFY_16,
+		WRITE_10,
+		WRITE_12,
+		WRITE_16,
+		WRITE_6,
+		WRITE_VERIFY,
+		WRITE_VERIFY_12,
+		WRITE_VERIFY_16
+	};
+	bs_create_opcode_map(&io_uring_bst, opcodes, ARRAY_SIZE(opcodes));
+	register_backingstore_template(&io_uring_bst);
+}
+

--- a/usr/bs_io_uring.c
+++ b/usr/bs_io_uring.c
@@ -44,7 +44,7 @@
 #include "scsi.h"
 #include <linux/time_types.h>
 
-#define IO_URING_MAX_IODEPTH 1024*16
+#define IO_URING_MAX_IODEPTH (1024 * 16)
 
 enum unmap_mode {
 	UNMAP_MODE_BLKDISCARD,
@@ -63,7 +63,7 @@ struct bs_io_uring_info {
 
 static inline struct bs_io_uring_info *BS_IO_URING_I(struct scsi_lu *lu)
 {
-	return (struct bs_io_uring_info *) ((char *)lu + sizeof(*lu));
+	return (struct bs_io_uring_info *)((char *)lu + sizeof(*lu));
 }
 
 static void cmd_error_sense(struct scsi_cmd *cmd, uint8_t key, uint16_t asc)
@@ -72,7 +72,8 @@ static void cmd_error_sense(struct scsi_cmd *cmd, uint8_t key, uint16_t asc)
 	sense_data_build(cmd, key, asc);
 }
 
-static void bs_io_uring_get_completions_helper(struct bs_io_uring_info *info) {
+static void bs_io_uring_get_completions_helper(struct bs_io_uring_info *info)
+{
 	struct io_uring_cqe *cqe;
 	unsigned head;
 	unsigned i = 0;
@@ -81,28 +82,32 @@ static void bs_io_uring_get_completions_helper(struct bs_io_uring_info *info) {
 	uint64_t evts_complete;
 
 	while (1) {
-		int ret = read(info->evt_fd, &evts_complete, sizeof(evts_complete));
+		int ret = read(info->evt_fd, &evts_complete,
+			       sizeof(evts_complete));
 		if (ret < 0) {
 			switch (errno) {
-				case EINTR:
-					continue;
-				case EAGAIN:
-					// EAGAIN in non-blocking evt_fd means nothing is available
-					return;
-				default:
-					eprintf("failed to read IO_URING completions, %m\n");
-					return;
+			case EINTR:
+				continue;
+			case EAGAIN:
+				// EAGAIN in non-blocking evt_fd means nothing is available
+				return;
+			default:
+				eprintf("failed to read IO_URING completions, %m\n");
+				return;
 			}
 		}
 		break;
 	}
 
-	io_uring_for_each_cqe(&info->ring, head, cqe) {
-		struct scsi_cmd* cmd = (struct scsi_cmd*) io_uring_cqe_get_data(cqe);
+	io_uring_for_each_cqe(&info->ring, head, cqe)
+	{
+		struct scsi_cmd *cmd =
+			(struct scsi_cmd *)io_uring_cqe_get_data(cqe);
 		if (cmd != NULL) {
 			int result = SAM_STAT_GOOD;
 			if (unlikely(cqe->res < 0)) {
-				eprintf("error in async operation: %s\n", strerror(-cqe->res));
+				eprintf("error in async operation: %s\n",
+					strerror(-cqe->res));
 				sense_data_build(cmd, MEDIUM_ERROR, 0);
 				result = SAM_STAT_CHECK_CONDITION;
 			}
@@ -117,16 +122,18 @@ static void bs_io_uring_get_completions_helper(struct bs_io_uring_info *info) {
 	io_uring_cq_advance(&info->ring, i);
 }
 
-static int queue_read(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
+static int queue_read(struct bs_io_uring_info *info, struct scsi_cmd *cmd)
+{
 	struct io_uring_sqe *sqe;
 	sqe = io_uring_get_sqe(&info->ring);
-    if (!sqe) {
-        return -1;
-    }
+	if (!sqe) {
+		return -1;
+	}
 
 	io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
 	io_uring_sqe_set_data(sqe, cmd);
-	io_uring_prep_read(sqe, 0, scsi_get_in_buffer(cmd), scsi_get_in_length(cmd), cmd->offset);
+	io_uring_prep_read(sqe, 0, scsi_get_in_buffer(cmd),
+			   scsi_get_in_length(cmd), cmd->offset);
 	set_cmd_async(cmd);
 
 	info->npending++;
@@ -134,16 +141,18 @@ static int queue_read(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
 	return 0;
 }
 
-static int queue_write(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
+static int queue_write(struct bs_io_uring_info *info, struct scsi_cmd *cmd)
+{
 	struct io_uring_sqe *sqe;
 	sqe = io_uring_get_sqe(&info->ring);
-    if (!sqe) {
-        return -1;
-    }
+	if (!sqe) {
+		return -1;
+	}
 
 	io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
 	io_uring_sqe_set_data(sqe, cmd);
-	io_uring_prep_write(sqe, 0, scsi_get_out_buffer(cmd), scsi_get_out_length(cmd), cmd->offset);
+	io_uring_prep_write(sqe, 0, scsi_get_out_buffer(cmd),
+			    scsi_get_out_length(cmd), cmd->offset);
 	set_cmd_async(cmd);
 
 	info->npending++;
@@ -151,12 +160,13 @@ static int queue_write(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
 	return 0;
 }
 
-static int queue_sync(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
+static int queue_sync(struct bs_io_uring_info *info, struct scsi_cmd *cmd)
+{
 	struct io_uring_sqe *sqe;
 	sqe = io_uring_get_sqe(&info->ring);
-    if (!sqe) {
-        return -1;
-    }
+	if (!sqe) {
+		return -1;
+	}
 
 	if (cmd->scb[0] == SYNCHRONIZE_CACHE_16) {
 		sqe->off = cmd->offset;
@@ -173,9 +183,10 @@ static int queue_sync(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
 	return 0;
 }
 
-static int queue_unmap(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
+static int queue_unmap(struct bs_io_uring_info *info, struct scsi_cmd *cmd)
+{
 	uint32_t length = scsi_get_out_length(cmd);
-	char* tmpbuf = scsi_get_out_buffer(cmd);
+	char *tmpbuf = scsi_get_out_buffer(cmd);
 
 	if (length < 8)
 		return 0;
@@ -202,47 +213,57 @@ static int queue_unmap(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
 			dprintf("unmap offset %lu length %u\n", offset, tl);
 
 			switch (info->unmap_mode) {
-				case UNMAP_MODE_FALLOCATE:
-					#ifdef FALLOC_FL_PUNCH_HOLE
-						while (info->npending >= info->iodepth) {
-							bs_io_uring_get_completions_helper(info);
-						}
-						struct io_uring_sqe *sqe;
-						sqe = io_uring_get_sqe(&info->ring);
-						if (!sqe) {
-							return -1;
-						}
-						io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
-						if (num_discards == 1){
-							io_uring_sqe_set_data(sqe, cmd);
-						} else {
-							io_uring_sqe_set_data(sqe, NULL);
-							sqe->flags |= IOSQE_IO_LINK;
-						}
-						dprintf("sending fallocate o: %lu l %u\n", offset, tl);
-						io_uring_prep_fallocate(sqe, 0, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, tl);
-						io_uring_submit(&info->ring);
-						info->npending++;
-						set_cmd_async(cmd);
-					#endif
-					break;
-				case UNMAP_MODE_BLKDISCARD:
-					#ifdef BLKDISCARD
-						// We have to send a sync request here to use ioctl
-						uint64_t range[] = { offset, tl };
-						dprintf("sending BLKDISCARD o: %lu l: %lu\n", range[0], range[1]);
-						int ret = ioctl(cmd->dev->fd, BLKDISCARD, &range);
-						if (ret) {
-							eprintf("BLKDISCARD got code %d %s\n", ret, strerror(-ret));
-							cmd_error_sense(cmd, HARDWARE_ERROR,
-								ASC_INTERNAL_TGT_FAILURE);
-							return ret;
-						}
-					#endif
-					break;
-				default:
-					eprintf("Ignoring UNMAP request\n");
-					break;
+			case UNMAP_MODE_FALLOCATE:
+#ifdef FALLOC_FL_PUNCH_HOLE
+				while (info->npending >= info->iodepth) {
+					bs_io_uring_get_completions_helper(
+						info);
+				}
+				struct io_uring_sqe *sqe;
+				sqe = io_uring_get_sqe(&info->ring);
+				if (!sqe) {
+					return -1;
+				}
+				io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
+				if (num_discards == 1) {
+					io_uring_sqe_set_data(sqe, cmd);
+				} else {
+					io_uring_sqe_set_data(sqe, NULL);
+					sqe->flags |= IOSQE_IO_LINK;
+				}
+				dprintf("sending fallocate o: %lu l %u\n",
+					offset, tl);
+				io_uring_prep_fallocate(
+					sqe, 0,
+					FALLOC_FL_PUNCH_HOLE |
+						FALLOC_FL_KEEP_SIZE,
+					offset, tl);
+				io_uring_submit(&info->ring);
+				info->npending++;
+				set_cmd_async(cmd);
+#endif
+				break;
+			case UNMAP_MODE_BLKDISCARD:
+#ifdef BLKDISCARD
+				// We have to send a sync request here to use ioctl
+				uint64_t range[] = { offset, tl };
+				dprintf("sending BLKDISCARD o: %lu l: %lu\n",
+					range[0], range[1]);
+				int ret =
+					ioctl(cmd->dev->fd, BLKDISCARD, &range);
+				if (ret) {
+					eprintf("BLKDISCARD got code %d %s\n",
+						ret, strerror(-ret));
+					cmd_error_sense(
+						cmd, HARDWARE_ERROR,
+						ASC_INTERNAL_TGT_FAILURE);
+					return ret;
+				}
+#endif
+				break;
+			default:
+				eprintf("Ignoring UNMAP request\n");
+				break;
 			}
 		}
 
@@ -286,7 +307,8 @@ static int bs_io_uring_cmd_submit(struct scsi_cmd *cmd)
 	case SYNCHRONIZE_CACHE:
 	case SYNCHRONIZE_CACHE_16:
 		if (cmd->scb[1] & 0x2) {
-			cmd_error_sense(cmd, ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
+			cmd_error_sense(cmd, ILLEGAL_REQUEST,
+					ASC_INVALID_FIELD_IN_CDB);
 			ret = -1;
 		} else {
 			ret = queue_sync(info, cmd);
@@ -312,8 +334,7 @@ static int bs_io_uring_cmd_submit(struct scsi_cmd *cmd)
 	}
 
 	if (scsi_get_result(cmd) != SAM_STAT_GOOD) {
-		eprintf("io error %p %x %d, %m\n",
-			cmd, cmd->scb[0], ret);
+		eprintf("io error %p %x %d, %m\n", cmd, cmd->scb[0], ret);
 	}
 
 	return 0;
@@ -325,7 +346,8 @@ static void bs_io_uring_get_completions(int fd, int events, void *data)
 	bs_io_uring_get_completions_helper(info);
 }
 
-static int bs_io_uring_open(struct scsi_lu *lu, char *path, int *fd, uint64_t *size)
+static int bs_io_uring_open(struct scsi_lu *lu, char *path, int *fd,
+			    uint64_t *size)
 {
 	struct bs_io_uring_info *info = BS_IO_URING_I(lu);
 	struct io_uring_params params;
@@ -334,53 +356,53 @@ static int bs_io_uring_open(struct scsi_lu *lu, char *path, int *fd, uint64_t *s
 
 	memset(&params, 0, sizeof(params));
 	params.flags |= IORING_SETUP_SQPOLL;
-    params.sq_thread_idle = 1000;
+	params.sq_thread_idle = 1000;
 
-	eprintf("create io_uring context for tgt:%d lun:%"PRId64 ", max iodepth:%d\n",
+	eprintf("create io_uring context for tgt:%d lun:%" PRId64
+		", max iodepth:%d\n",
 		info->lu->tgt->tid, info->lu->lun, info->iodepth);
 
-    ret = io_uring_queue_init_params(info->iodepth, &info->ring, &params);
-    if (ret) {
+	ret = io_uring_queue_init_params(info->iodepth, &info->ring, &params);
+	if (ret) {
 		eprintf("failed to init io_uring queue params, %m\n");
 		return ret;
 	}
 
 	int afd = eventfd(0, O_NONBLOCK);
 	if (afd < 0) {
-		eprintf("failed to create eventfd for tgt:%d lun:%"PRId64 ", %m\n",
+		eprintf("failed to create eventfd for tgt:%d lun:%" PRId64
+			", %m\n",
 			info->lu->tgt->tid, info->lu->lun);
 		ret = afd;
 		goto close_ctx;
 	}
-	dprintf("eventfd:%d for tgt:%d lun:%"PRId64 "\n",
-		afd, info->lu->tgt->tid, info->lu->lun);
+	dprintf("eventfd:%d for tgt:%d lun:%" PRId64 "\n", afd,
+		info->lu->tgt->tid, info->lu->lun);
 
 	ret = tgt_event_add(afd, EPOLLIN, bs_io_uring_get_completions, info);
 	if (ret)
 		goto close_eventfd;
 	info->evt_fd = afd;
 
-	eprintf("open %s, RW for tgt:%d lun:%"PRId64 "\n",
-		path, info->lu->tgt->tid, info->lu->lun);
-	*fd = backed_file_open(path, O_RDWR, size,
-				&blksize);
+	eprintf("open %s, RW for tgt:%d lun:%" PRId64 "\n", path,
+		info->lu->tgt->tid, info->lu->lun);
+	*fd = backed_file_open(path, O_RDWR, size, &blksize);
 	/* If we get access denied, try opening the file in readonly mode */
 	if (*fd == -1 && (errno == EACCES || errno == EROFS)) {
-		eprintf("open %s, READONLY for tgt:%d lun:%"PRId64 "\n",
-			path, info->lu->tgt->tid, info->lu->lun);
-		*fd = backed_file_open(path, O_RDONLY,
-				       size, &blksize);
+		eprintf("open %s, READONLY for tgt:%d lun:%" PRId64 "\n", path,
+			info->lu->tgt->tid, info->lu->lun);
+		*fd = backed_file_open(path, O_RDONLY, size, &blksize);
 		lu->attrs.readonly = 1;
 	}
 	if (*fd < 0) {
-		eprintf("failed to open %s, for tgt:%d lun:%"PRId64 ", %m\n",
+		eprintf("failed to open %s, for tgt:%d lun:%" PRId64 ", %m\n",
 			path, info->lu->tgt->tid, info->lu->lun);
 		ret = *fd;
 		goto remove_tgt_evt;
 	}
 
-	eprintf("%s opened successfully for tgt:%d lun:%"PRId64 "\n",
-		path, info->lu->tgt->tid, info->lu->lun);
+	eprintf("%s opened successfully for tgt:%d lun:%" PRId64 "\n", path,
+		info->lu->tgt->tid, info->lu->lun);
 
 	struct stat st;
 	if (fstat(*fd, &st) < 0) {
@@ -395,17 +417,17 @@ static int bs_io_uring_open(struct scsi_lu *lu, char *path, int *fd, uint64_t *s
 	} else {
 		info->unmap_mode = UNMAP_MODE_NONE;
 	}
-	
+
 	ret = io_uring_register_files(&info->ring, fd, 1);
-    if(ret) {
-        eprintf("failed to register buffers: %s\n", strerror(-ret));
-        goto remove_tgt_evt;
-    }
+	if (ret) {
+		eprintf("failed to register buffers: %s\n", strerror(-ret));
+		goto remove_tgt_evt;
+	}
 	ret = io_uring_register_eventfd(&info->ring, info->evt_fd);
-	if(ret) {
-        eprintf("failed to register eventfd: %s\n", strerror(-ret));
-        goto remove_tgt_evt;
-    }
+	if (ret) {
+		eprintf("failed to register eventfd: %s\n", strerror(-ret));
+		goto remove_tgt_evt;
+	}
 
 	if (!lu->attrs.no_auto_lbppbe)
 		update_lbppbe(lu, blksize);
@@ -417,7 +439,7 @@ remove_tgt_evt:
 close_eventfd:
 	close(afd);
 close_ctx:
-    io_uring_queue_exit(&info->ring);
+	io_uring_queue_exit(&info->ring);
 	return ret;
 }
 
@@ -442,64 +464,61 @@ static void bs_io_uring_exit(struct scsi_lu *lu)
 	struct bs_io_uring_info *info = BS_IO_URING_I(lu);
 	tgt_event_del(info->evt_fd);
 	close(info->evt_fd);
-    io_uring_queue_exit(&info->ring);
+	io_uring_queue_exit(&info->ring);
 }
 
 static struct backingstore_template io_uring_bst = {
-	.bs_name		= "io_uring",
-	.bs_datasize    	= sizeof(struct bs_io_uring_info),
-	.bs_init		= bs_io_uring_init,
-	.bs_exit		= bs_io_uring_exit,
-	.bs_open		= bs_io_uring_open,
-	.bs_close       	= bs_io_uring_close,
-	.bs_cmd_submit  	= bs_io_uring_cmd_submit,
+	.bs_name = "io_uring",
+	.bs_datasize = sizeof(struct bs_io_uring_info),
+	.bs_init = bs_io_uring_init,
+	.bs_exit = bs_io_uring_exit,
+	.bs_open = bs_io_uring_open,
+	.bs_close = bs_io_uring_close,
+	.bs_cmd_submit = bs_io_uring_cmd_submit,
 };
 
 __attribute__((constructor)) static void register_bs_module(void)
 {
-	unsigned char opcodes[] = {
-		ALLOW_MEDIUM_REMOVAL,
-		COMPARE_AND_WRITE,
-		FORMAT_UNIT,
-		INQUIRY,
-		MAINT_PROTOCOL_IN,
-		MODE_SELECT,
-		MODE_SELECT_10,
-		MODE_SENSE,
-		MODE_SENSE_10,
-		ORWRITE_16,
-		PERSISTENT_RESERVE_IN,
-		PERSISTENT_RESERVE_OUT,
-		PRE_FETCH_10,
-		PRE_FETCH_16,
-		READ_10,
-		READ_12,
-		READ_16,
-		READ_6,
-		READ_CAPACITY,
-		RELEASE,
-		REPORT_LUNS,
-		REQUEST_SENSE,
-		RESERVE,
-		SEND_DIAGNOSTIC,
-		SERVICE_ACTION_IN,
-		START_STOP,
-		SYNCHRONIZE_CACHE,
-		SYNCHRONIZE_CACHE_16,
-		TEST_UNIT_READY,
-		UNMAP,
-		VERIFY_10,
-		VERIFY_12,
-		VERIFY_16,
-		WRITE_10,
-		WRITE_12,
-		WRITE_16,
-		WRITE_6,
-		WRITE_VERIFY,
-		WRITE_VERIFY_12,
-		WRITE_VERIFY_16
-	};
+	unsigned char opcodes[] = { ALLOW_MEDIUM_REMOVAL,
+				    COMPARE_AND_WRITE,
+				    FORMAT_UNIT,
+				    INQUIRY,
+				    MAINT_PROTOCOL_IN,
+				    MODE_SELECT,
+				    MODE_SELECT_10,
+				    MODE_SENSE,
+				    MODE_SENSE_10,
+				    ORWRITE_16,
+				    PERSISTENT_RESERVE_IN,
+				    PERSISTENT_RESERVE_OUT,
+				    PRE_FETCH_10,
+				    PRE_FETCH_16,
+				    READ_10,
+				    READ_12,
+				    READ_16,
+				    READ_6,
+				    READ_CAPACITY,
+				    RELEASE,
+				    REPORT_LUNS,
+				    REQUEST_SENSE,
+				    RESERVE,
+				    SEND_DIAGNOSTIC,
+				    SERVICE_ACTION_IN,
+				    START_STOP,
+				    SYNCHRONIZE_CACHE,
+				    SYNCHRONIZE_CACHE_16,
+				    TEST_UNIT_READY,
+				    UNMAP,
+				    VERIFY_10,
+				    VERIFY_12,
+				    VERIFY_16,
+				    WRITE_10,
+				    WRITE_12,
+				    WRITE_16,
+				    WRITE_6,
+				    WRITE_VERIFY,
+				    WRITE_VERIFY_12,
+				    WRITE_VERIFY_16 };
 	bs_create_opcode_map(&io_uring_bst, opcodes, ARRAY_SIZE(opcodes));
 	register_backingstore_template(&io_uring_bst);
 }
-

--- a/usr/bs_io_uring.c
+++ b/usr/bs_io_uring.c
@@ -339,7 +339,7 @@ static int bs_io_uring_open(struct scsi_lu *lu, char *path, int *fd, uint64_t *s
 
 	memset(&params, 0, sizeof(params));
 	params.flags |= IORING_SETUP_SQPOLL;
-    params.sq_thread_idle = 5000;
+    params.sq_thread_idle = 1000;
 
 	eprintf("create io_uring context for tgt:%d lun:%"PRId64 ", max iodepth:%d\n",
 		info->lu->tgt->tid, info->lu->lun, info->iodepth);

--- a/usr/bs_io_uring.c
+++ b/usr/bs_io_uring.c
@@ -193,8 +193,6 @@ static int queue_unmap(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
 	tmpbuf += 8;
 
 	int num_discards = length / 16;
-	printf("Will queue %d discards\n", num_discards);
-
 	while (num_discards > 0) {
 		uint64_t offset = get_unaligned_be64(&tmpbuf[0]);
 		offset = offset << cmd->dev->blk_shift;

--- a/usr/bs_io_uring.c
+++ b/usr/bs_io_uring.c
@@ -74,14 +74,16 @@ static void cmd_error_sense(struct scsi_cmd *cmd, uint8_t key, uint16_t asc)
 
 static void bs_io_uring_get_completions_helper(struct bs_io_uring_info *info) {
 	struct io_uring_cqe *cqe;
+	unsigned head;
+	unsigned i = 0;
 	/* read from eventfd returns 8-byte int, fails with the error EINVAL
 	   if the size of the supplied buffer is less than 8 bytes */
 	uint64_t evts_complete;
 
-	struct __kernel_timespec ts = {
-		.tv_nsec = 0,
-		.tv_sec = 0,
-	};
+	// struct __kernel_timespec ts = {
+	// 	.tv_nsec = 0,
+	// 	.tv_sec = 0,
+	// };
 
 retry_read:
 	int ret = read(info->evt_fd, &evts_complete, sizeof(evts_complete));
@@ -99,16 +101,7 @@ retry_read:
 		}
 	}
 
-	while (true) {
-		int ret = io_uring_wait_cqe_timeout(&info->ring, &cqe, &ts);
-		if (ret == -ETIME) {
-			// We really do have nothing to read here, so bail out
-			return;
-		} else if (unlikely(ret < 0)) {
-            eprintf("error waiting for completion: %s\n", strerror(-ret));
-			break;
-        }
-
+	io_uring_for_each_cqe(&info->ring, head, cqe) {
 		struct scsi_cmd* cmd = (struct scsi_cmd*) io_uring_cqe_get_data(cqe);
 		if (cmd != NULL) {
 			int result = SAM_STAT_GOOD;
@@ -121,9 +114,11 @@ retry_read:
 			target_cmd_io_done(cmd, result);
 		}
 
-		io_uring_cqe_seen(&info->ring, cqe);
 		info->npending--;
+		i++;
 	}
+
+	io_uring_cq_advance(&info->ring, i);
 }
 
 static int queue_read(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {

--- a/usr/bs_io_uring.c
+++ b/usr/bs_io_uring.c
@@ -72,37 +72,40 @@ static void bs_io_uring_get_completions_helper(struct bs_io_uring_info *info) {
 	   if the size of the supplied buffer is less than 8 bytes */
 	uint64_t evts_complete;
 
-	struct __kernel_timespec ts;
-	ts.tv_nsec = 0;
-	ts.tv_sec = 0;
+	struct __kernel_timespec ts = {
+		.tv_nsec = 0,
+		.tv_sec = 0,
+	};
 
 retry_read:
 	int ret = read(info->evt_fd, &evts_complete, sizeof(evts_complete));
 	if (ret < 0) {
-		if (errno == EINTR) {
-			goto retry_read;
-		} else if (errno != EAGAIN) {
-			printf("e: failed to read IO_URING completions, %m\n");
-			return;
+		switch (errno) {
+			case EINTR:
+				goto retry_read;
+			case EAGAIN:
+				// EAGAIN in non-blocking evt_fd means nothing is available
+				// Still we want to continue in case some accounting error came up
+				break;
+			default:
+				printf("e: failed to read IO_URING completions, %m\n");
+				return;
 		}
-		evts_complete = 0;
 	}
-
-	if (info->npending > 0 || evts_complete > 0)
-		printf("npending: %d, event_pending: %lu\n", info->npending, evts_complete);
 
 	while (true) {
 		int ret = io_uring_wait_cqe_timeout(&info->ring, &cqe, &ts);
 		if (ret == -ETIME) {
-			break;
-		} else if (ret < 0) {
+			// We really do have nothing to read here, so bail out
+			return;
+		} else if (unlikely(ret < 0)) {
             printf("e: error waiting for completion: %s\n", strerror(-ret));
 			break;
         }
 
 		struct scsi_cmd* cmd = (struct scsi_cmd*) io_uring_cqe_get_data(cqe);
-		int result = SAM_STAT_GOOD;
 
+		int result = SAM_STAT_GOOD;
 		if (unlikely(cqe->res < 0)) {
             printf("e: error in async operation: %s\n", strerror(-cqe->res));
 			sense_data_build(cmd, MEDIUM_ERROR, 0);
@@ -110,20 +113,16 @@ retry_read:
         }
 
         io_uring_cqe_seen(&info->ring, cqe);
-		target_cmd_io_done(cmd, result);
 		info->npending--;
+		target_cmd_io_done(cmd, result);
 	}
 }
 
 static int queue_read(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
-	while (info->npending >= info->iodepth) {
-		bs_io_uring_get_completions_helper(info);
-	}
-	
 	struct io_uring_sqe *sqe;
 	sqe = io_uring_get_sqe(&info->ring);
     if (!sqe) {
-        return 1;
+        return -1;
     }
 
 	io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
@@ -137,14 +136,10 @@ static int queue_read(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
 }
 
 static int queue_write(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
-	while (info->npending >= info->iodepth) {
-		bs_io_uring_get_completions_helper(info);
-	}
-
 	struct io_uring_sqe *sqe;
 	sqe = io_uring_get_sqe(&info->ring);
     if (!sqe) {
-        return 1;
+        return -1;
     }
 
 	io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
@@ -158,23 +153,19 @@ static int queue_write(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
 }
 
 static int queue_sync(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
-	while (info->npending >= info->iodepth) {
-		bs_io_uring_get_completions_helper(info);
-	}
-	
 	struct io_uring_sqe *sqe;
 	sqe = io_uring_get_sqe(&info->ring);
     if (!sqe) {
-        return 1;
+        return -1;
     }
 
 	if (cmd->scb[0] == SYNCHRONIZE_CACHE_16) {
 		sqe->off = cmd->offset;
 		sqe->len = scsi_get_in_length(cmd);
 	}
+
 	io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
 	io_uring_sqe_set_data(sqe, cmd);
-	printf("d: fdatasync offset %llu len %u\n", sqe->off, sqe->len);
 	io_uring_prep_fsync(sqe, 0, IORING_FSYNC_DATASYNC);
 	set_cmd_async(cmd);
 
@@ -218,34 +209,35 @@ static int queue_unmap(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
 
 			if (S_ISREG(st.st_mode)) {
 			#ifdef FALLOC_FL_PUNCH_HOLE
-				while (info->npending >= info->iodepth) {
-					bs_io_uring_get_completions_helper(info);
-				}
 				struct io_uring_sqe *sqe;
 				sqe = io_uring_get_sqe(&info->ring);
 				if (!sqe) {
-					return 1;
+					return -1;
 				}
 				printf("d: sending fallocate\n");
 				io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
 				io_uring_sqe_set_data(sqe, cmd);
 				io_uring_prep_fallocate(sqe, 0, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, tl);
-				set_cmd_async(cmd);
 				info->npending++;
+				io_uring_submit(&info->ring);
+				set_cmd_async(cmd);
 			#endif
 			} else if (S_ISBLK(st.st_mode)) {
 			#ifdef BLKDISCARD
-				// We have to send a sync request here
+				// We have to send a sync request here to use ioctl
 				uint64_t range[] = { offset, tl };
 				printf("d: sending BLKDISCARD o: %lu l: %lu\n", range[0], range[1]);
 				int ret = ioctl(cmd->dev->fd, BLKDISCARD, &range);
 				if (ret) {
 					printf("e: BLKDISCARD got code %d %s\n", ret, strerror(-ret));
+					cmd_error_sense(cmd, HARDWARE_ERROR,
+						ASC_INTERNAL_TGT_FAILURE);
 					return ret;
 				}
 			#endif
 			} else {
-				return -1;
+				printf("DISCARD FAIL\n");
+				return -2;
 			}
 		}
 
@@ -253,7 +245,6 @@ static int queue_unmap(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
 		tmpbuf += 16;
 	}
 
-	io_uring_submit(&info->ring);
 	return 0;
 }
 
@@ -263,6 +254,10 @@ static int bs_io_uring_cmd_submit(struct scsi_cmd *cmd)
 	struct bs_io_uring_info *info = BS_IO_URING_I(lu);
 	unsigned int scsi_op = (unsigned int)cmd->scb[0];
 	int ret;
+
+	while (info->npending >= info->iodepth) {
+		bs_io_uring_get_completions_helper(info);
+	}
 
 	switch (scsi_op) {
 	case WRITE_6:
@@ -296,9 +291,9 @@ static int bs_io_uring_cmd_submit(struct scsi_cmd *cmd)
 			cmd_error_sense(cmd, ILLEGAL_REQUEST,
 					ASC_INVALID_FIELD_IN_CDB);
 			ret = -1;
-			break;
+		} else {
+			ret = queue_unmap(info, cmd);
 		}
-		ret = queue_unmap(info, cmd);
 		break;
 	case WRITE_SAME:
 	case WRITE_SAME_16:
@@ -310,7 +305,12 @@ static int bs_io_uring_cmd_submit(struct scsi_cmd *cmd)
 		ret = 0;
 	}
 
-	return ret;
+	if (scsi_get_result(cmd) != SAM_STAT_GOOD) {
+		printf("e: io error %p %x %d, %m\n",
+			cmd, cmd->scb[0], ret);
+	}
+
+	return 0;
 }
 
 static void bs_io_uring_get_completions(int fd, int events, void *data)

--- a/usr/bs_io_uring.c
+++ b/usr/bs_io_uring.c
@@ -80,24 +80,21 @@ static void bs_io_uring_get_completions_helper(struct bs_io_uring_info *info) {
 	   if the size of the supplied buffer is less than 8 bytes */
 	uint64_t evts_complete;
 
-	// struct __kernel_timespec ts = {
-	// 	.tv_nsec = 0,
-	// 	.tv_sec = 0,
-	// };
-
-retry_read:
-	int ret = read(info->evt_fd, &evts_complete, sizeof(evts_complete));
-	if (ret < 0) {
-		switch (errno) {
-			case EINTR:
-				goto retry_read;
-			case EAGAIN:
-				// EAGAIN in non-blocking evt_fd means nothing is available
-				return;
-			default:
-				eprintf("failed to read IO_URING completions, %m\n");
-				return;
+	while (1) {
+		int ret = read(info->evt_fd, &evts_complete, sizeof(evts_complete));
+		if (ret < 0) {
+			switch (errno) {
+				case EINTR:
+					continue;
+				case EAGAIN:
+					// EAGAIN in non-blocking evt_fd means nothing is available
+					return;
+				default:
+					eprintf("failed to read IO_URING completions, %m\n");
+					return;
+			}
 		}
+		break;
 	}
 
 	io_uring_for_each_cqe(&info->ring, head, cqe) {
@@ -226,6 +223,7 @@ static int queue_unmap(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
 						io_uring_prep_fallocate(sqe, 0, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, tl);
 						io_uring_submit(&info->ring);
 						info->npending++;
+						set_cmd_async(cmd);
 					#endif
 					break;
 				case UNMAP_MODE_BLKDISCARD:
@@ -253,9 +251,6 @@ static int queue_unmap(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
 		num_discards -= 1;
 	}
 
-	if (info->unmap_mode == UNMAP_MODE_FALLOCATE) {
-		set_cmd_async(cmd);
-	}
 	return 0;
 }
 

--- a/usr/bs_io_uring.c
+++ b/usr/bs_io_uring.c
@@ -46,12 +46,19 @@
 
 #define IO_URING_MAX_IODEPTH 1024
 
+enum unmap_mode {
+	UNMAP_MODE_BLKDISCARD,
+	UNMAP_MODE_FALLOCATE,
+	UNMAP_MODE_NONE,
+};
+
 struct bs_io_uring_info {
 	struct io_uring ring;
 	struct scsi_lu *lu;
 	int evt_fd;
 	unsigned int npending;
 	unsigned int iodepth;
+	enum unmap_mode unmap_mode;
 };
 
 static inline struct bs_io_uring_info *BS_IO_URING_I(struct scsi_lu *lu)
@@ -66,7 +73,6 @@ static void cmd_error_sense(struct scsi_cmd *cmd, uint8_t key, uint16_t asc)
 }
 
 static void bs_io_uring_get_completions_helper(struct bs_io_uring_info *info) {
-	// printf("bs_io_uring_get_completions_helper called\n");
 	struct io_uring_cqe *cqe;
 	/* read from eventfd returns 8-byte int, fails with the error EINVAL
 	   if the size of the supplied buffer is less than 8 bytes */
@@ -88,7 +94,7 @@ retry_read:
 				// Still we want to continue in case some accounting error came up
 				break;
 			default:
-				printf("e: failed to read IO_URING completions, %m\n");
+				eprintf("failed to read IO_URING completions, %m\n");
 				return;
 		}
 	}
@@ -99,22 +105,24 @@ retry_read:
 			// We really do have nothing to read here, so bail out
 			return;
 		} else if (unlikely(ret < 0)) {
-            printf("e: error waiting for completion: %s\n", strerror(-ret));
+            eprintf("error waiting for completion: %s\n", strerror(-ret));
 			break;
         }
 
 		struct scsi_cmd* cmd = (struct scsi_cmd*) io_uring_cqe_get_data(cqe);
+		if (cmd != NULL) {
+			int result = SAM_STAT_GOOD;
+			if (unlikely(cqe->res < 0)) {
+				eprintf("error in async operation: %s\n", strerror(-cqe->res));
+				sense_data_build(cmd, MEDIUM_ERROR, 0);
+				result = SAM_STAT_CHECK_CONDITION;
+			}
 
-		int result = SAM_STAT_GOOD;
-		if (unlikely(cqe->res < 0)) {
-            printf("e: error in async operation: %s\n", strerror(-cqe->res));
-			sense_data_build(cmd, MEDIUM_ERROR, 0);
-			result = SAM_STAT_CHECK_CONDITION;
-        }
+			target_cmd_io_done(cmd, result);
+		}
 
-        io_uring_cqe_seen(&info->ring, cqe);
+		io_uring_cqe_seen(&info->ring, cqe);
 		info->npending--;
-		target_cmd_io_done(cmd, result);
 	}
 }
 
@@ -181,16 +189,13 @@ static int queue_unmap(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
 	if (length < 8)
 		return 0;
 
-	struct stat st;
-	if (fstat(cmd->dev->fd, &st) < 0) {
-		printf("fstat fail\n");
-		return -1;
-	}
-
 	length -= 8;
 	tmpbuf += 8;
 
-	while (length >= 16) {
+	int num_discards = length / 16;
+	printf("Will queue %d discards\n", num_discards);
+
+	while (num_discards > 0) {
 		uint64_t offset = get_unaligned_be64(&tmpbuf[0]);
 		offset = offset << cmd->dev->blk_shift;
 
@@ -198,53 +203,67 @@ static int queue_unmap(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
 		tl = tl << cmd->dev->blk_shift;
 
 		if (offset + tl > cmd->dev->size) {
-			printf("e: UNMAP beyond EOF\n");
+			eprintf("UNMAP beyond EOF\n");
 			cmd_error_sense(cmd, ILLEGAL_REQUEST,
 					ASC_LBA_OUT_OF_RANGE);
-			break;
+			return 0;
 		}
 
 		if (tl > 0) {
-			printf("d: unmap offset %lu length %u\n", offset, tl);
+			dprintf("unmap offset %lu length %u\n", offset, tl);
 
-			if (S_ISREG(st.st_mode)) {
-			#ifdef FALLOC_FL_PUNCH_HOLE
-				struct io_uring_sqe *sqe;
-				sqe = io_uring_get_sqe(&info->ring);
-				if (!sqe) {
-					return -1;
-				}
-				printf("d: sending fallocate\n");
-				io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
-				io_uring_sqe_set_data(sqe, cmd);
-				io_uring_prep_fallocate(sqe, 0, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, tl);
-				info->npending++;
-				io_uring_submit(&info->ring);
-				set_cmd_async(cmd);
-			#endif
-			} else if (S_ISBLK(st.st_mode)) {
-			#ifdef BLKDISCARD
-				// We have to send a sync request here to use ioctl
-				uint64_t range[] = { offset, tl };
-				printf("d: sending BLKDISCARD o: %lu l: %lu\n", range[0], range[1]);
-				int ret = ioctl(cmd->dev->fd, BLKDISCARD, &range);
-				if (ret) {
-					printf("e: BLKDISCARD got code %d %s\n", ret, strerror(-ret));
-					cmd_error_sense(cmd, HARDWARE_ERROR,
-						ASC_INTERNAL_TGT_FAILURE);
-					return ret;
-				}
-			#endif
-			} else {
-				printf("DISCARD FAIL\n");
-				return -2;
+			switch (info->unmap_mode) {
+				case UNMAP_MODE_FALLOCATE:
+					#ifdef FALLOC_FL_PUNCH_HOLE
+						while (info->npending >= info->iodepth) {
+							bs_io_uring_get_completions_helper(info);
+						}
+						struct io_uring_sqe *sqe;
+						sqe = io_uring_get_sqe(&info->ring);
+						if (!sqe) {
+							return -1;
+						}
+						io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
+						if (num_discards == 1){
+							io_uring_sqe_set_data(sqe, cmd);
+						} else {
+							io_uring_sqe_set_data(sqe, NULL);
+							sqe->flags |= IOSQE_IO_LINK;
+						}
+						dprintf("sending fallocate o: %lu l %u\n", offset, tl);
+						io_uring_prep_fallocate(sqe, 0, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, tl);
+						io_uring_submit(&info->ring);
+						info->npending++;
+					#endif
+					break;
+				case UNMAP_MODE_BLKDISCARD:
+					#ifdef BLKDISCARD
+						// We have to send a sync request here to use ioctl
+						uint64_t range[] = { offset, tl };
+						dprintf("sending BLKDISCARD o: %lu l: %lu\n", range[0], range[1]);
+						int ret = ioctl(cmd->dev->fd, BLKDISCARD, &range);
+						if (ret) {
+							eprintf("BLKDISCARD got code %d %s\n", ret, strerror(-ret));
+							cmd_error_sense(cmd, HARDWARE_ERROR,
+								ASC_INTERNAL_TGT_FAILURE);
+							return ret;
+						}
+					#endif
+					break;
+				default:
+					printf("Ignoring discard request\n");
+					break;
 			}
 		}
 
 		length -= 16;
 		tmpbuf += 16;
+		num_discards -= 1;
 	}
 
+	if (info->unmap_mode == UNMAP_MODE_FALLOCATE) {
+		set_cmd_async(cmd);
+	}
 	return 0;
 }
 
@@ -266,7 +285,7 @@ static int bs_io_uring_cmd_submit(struct scsi_cmd *cmd)
 	case WRITE_16:
 		ret = queue_write(info, cmd);
 
-		// printf("d: write offset: %lx\n", cmd->offset);
+		// dprintf("write offset: %lx\n", cmd->offset);
 		break;
 
 	case READ_6:
@@ -275,7 +294,7 @@ static int bs_io_uring_cmd_submit(struct scsi_cmd *cmd)
 	case READ_16:
 		ret = queue_read(info, cmd);
 
-		// printf("d: read offset: %lx\n", cmd->offset);
+		// dprintf("read offset: %lx\n", cmd->offset);
 		break;
 	case SYNCHRONIZE_CACHE:
 	case SYNCHRONIZE_CACHE_16:
@@ -297,16 +316,16 @@ static int bs_io_uring_cmd_submit(struct scsi_cmd *cmd)
 		break;
 	case WRITE_SAME:
 	case WRITE_SAME_16:
-		printf("d: WRITE_SAME not yet supported for IO_URING backend.\n");
+		dprintf("WRITE_SAME not yet supported for IO_URING backend.\n");
 		ret = -1;
 		break;
 	default:
-		printf("d: skipped cmd:%p op:%x\n", cmd, scsi_op);
+		dprintf("skipped cmd:%p op:%x\n", cmd, scsi_op);
 		ret = 0;
 	}
 
 	if (scsi_get_result(cmd) != SAM_STAT_GOOD) {
-		printf("e: io error %p %x %d, %m\n",
+		eprintf("io error %p %x %d, %m\n",
 			cmd, cmd->scb[0], ret);
 	}
 
@@ -315,7 +334,6 @@ static int bs_io_uring_cmd_submit(struct scsi_cmd *cmd)
 
 static void bs_io_uring_get_completions(int fd, int events, void *data)
 {
-	// printf("bs_io_uring_get_completions called\n");
 	struct bs_io_uring_info *info = data;
 	bs_io_uring_get_completions_helper(info);
 }
@@ -331,12 +349,12 @@ static int bs_io_uring_open(struct scsi_lu *lu, char *path, int *fd, uint64_t *s
 	params.flags |= IORING_SETUP_SQPOLL;
     params.sq_thread_idle = 5000;
 
-	printf("e: create io_uring context for tgt:%d lun:%"PRId64 ", max iodepth:%d\n",
+	eprintf("create io_uring context for tgt:%d lun:%"PRId64 ", max iodepth:%d\n",
 		info->lu->tgt->tid, info->lu->lun, info->iodepth);
 
     ret = io_uring_queue_init_params(info->iodepth, &info->ring, &params);
     if (ret) {
-		printf("e: failed to init io_uring queue params, %m\n");
+		eprintf("failed to init io_uring queue params, %m\n");
 		return ret;
 	}
 
@@ -347,7 +365,7 @@ static int bs_io_uring_open(struct scsi_lu *lu, char *path, int *fd, uint64_t *s
 		ret = afd;
 		goto close_ctx;
 	}
-	printf("d: eventfd:%d for tgt:%d lun:%"PRId64 "\n",
+	dprintf("eventfd:%d for tgt:%d lun:%"PRId64 "\n",
 		afd, info->lu->tgt->tid, info->lu->lun);
 
 	ret = tgt_event_add(afd, EPOLLIN, bs_io_uring_get_completions, info);
@@ -355,36 +373,50 @@ static int bs_io_uring_open(struct scsi_lu *lu, char *path, int *fd, uint64_t *s
 		goto close_eventfd;
 	info->evt_fd = afd;
 
-	printf("e: open %s, RW for tgt:%d lun:%"PRId64 "\n",
+	eprintf("open %s, RW for tgt:%d lun:%"PRId64 "\n",
 		path, info->lu->tgt->tid, info->lu->lun);
 	*fd = backed_file_open(path, O_RDWR, size,
 				&blksize);
 	/* If we get access denied, try opening the file in readonly mode */
 	if (*fd == -1 && (errno == EACCES || errno == EROFS)) {
-		printf("e: open %s, READONLY for tgt:%d lun:%"PRId64 "\n",
+		eprintf("open %s, READONLY for tgt:%d lun:%"PRId64 "\n",
 			path, info->lu->tgt->tid, info->lu->lun);
 		*fd = backed_file_open(path, O_RDONLY,
 				       size, &blksize);
 		lu->attrs.readonly = 1;
 	}
 	if (*fd < 0) {
-		printf("e: failed to open %s, for tgt:%d lun:%"PRId64 ", %m\n",
+		eprintf("failed to open %s, for tgt:%d lun:%"PRId64 ", %m\n",
 			path, info->lu->tgt->tid, info->lu->lun);
 		ret = *fd;
 		goto remove_tgt_evt;
 	}
 
-	printf("e: %s opened successfully for tgt:%d lun:%"PRId64 "\n",
+	eprintf("%s opened successfully for tgt:%d lun:%"PRId64 "\n",
 		path, info->lu->tgt->tid, info->lu->lun);
+
+	struct stat st;
+	if (fstat(*fd, &st) < 0) {
+		printf("fstat fail\n");
+		return -1;
+	}
+
+	if (S_ISREG(st.st_mode)) {
+		info->unmap_mode = UNMAP_MODE_FALLOCATE;
+	} else if (S_ISBLK(st.st_mode)) {
+		info->unmap_mode = UNMAP_MODE_BLKDISCARD;
+	} else {
+		info->unmap_mode = UNMAP_MODE_NONE;
+	}
 	
 	ret = io_uring_register_files(&info->ring, fd, 1);
     if(ret) {
-        printf("failed to register buffers: %s\n", strerror(-ret));
+        eprintf("failed to register buffers: %s\n", strerror(-ret));
         goto remove_tgt_evt;
     }
 	ret = io_uring_register_eventfd(&info->ring, info->evt_fd);
 	if(ret) {
-        printf("failed to register eventfd: %s\n", strerror(-ret));
+        eprintf("failed to register eventfd: %s\n", strerror(-ret));
         goto remove_tgt_evt;
     }
 

--- a/usr/bs_io_uring.c
+++ b/usr/bs_io_uring.c
@@ -68,15 +68,33 @@ static void cmd_error_sense(struct scsi_cmd *cmd, uint8_t key, uint16_t asc)
 static void bs_io_uring_get_completions_helper(struct bs_io_uring_info *info) {
 	// printf("bs_io_uring_get_completions_helper called\n");
 	struct io_uring_cqe *cqe;
+	/* read from eventfd returns 8-byte int, fails with the error EINVAL
+	   if the size of the supplied buffer is less than 8 bytes */
+	uint64_t evts_complete;
 
 	struct __kernel_timespec ts;
 	ts.tv_nsec = 0;
 	ts.tv_sec = 0;
 
+retry_read:
+	int ret = read(info->evt_fd, &evts_complete, sizeof(evts_complete));
+	if (ret < 0) {
+		if (errno == EINTR) {
+			goto retry_read;
+		} else if (errno != EAGAIN) {
+			printf("e: failed to read IO_URING completions, %m\n");
+			return;
+		}
+		evts_complete = 0;
+	}
+
+	if (info->npending > 0 || evts_complete > 0)
+		printf("npending: %d, event_pending: %lu\n", info->npending, evts_complete);
+
 	while (true) {
 		int ret = io_uring_wait_cqe_timeout(&info->ring, &cqe, &ts);
 		if (ret == -ETIME) {
-			return;
+			break;
 		} else if (ret < 0) {
             printf("e: error waiting for completion: %s\n", strerror(-ret));
 			break;
@@ -85,7 +103,7 @@ static void bs_io_uring_get_completions_helper(struct bs_io_uring_info *info) {
 		struct scsi_cmd* cmd = (struct scsi_cmd*) io_uring_cqe_get_data(cqe);
 		int result = SAM_STAT_GOOD;
 
-		if (cqe->res < 0) {
+		if (unlikely(cqe->res < 0)) {
             printf("e: error in async operation: %s\n", strerror(-cqe->res));
 			sense_data_build(cmd, MEDIUM_ERROR, 0);
 			result = SAM_STAT_CHECK_CONDITION;
@@ -108,9 +126,9 @@ static int queue_read(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
         return 1;
     }
 
-	// io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
+	io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
 	io_uring_sqe_set_data(sqe, cmd);
-	io_uring_prep_read(sqe, cmd->dev->fd, scsi_get_in_buffer(cmd), scsi_get_in_length(cmd), cmd->offset);
+	io_uring_prep_read(sqe, 0, scsi_get_in_buffer(cmd), scsi_get_in_length(cmd), cmd->offset);
 	set_cmd_async(cmd);
 
 	info->npending++;
@@ -129,9 +147,9 @@ static int queue_write(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
         return 1;
     }
 
-	// io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
+	io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
 	io_uring_sqe_set_data(sqe, cmd);
-	io_uring_prep_write(sqe, cmd->dev->fd, scsi_get_out_buffer(cmd), scsi_get_out_length(cmd), cmd->offset);
+	io_uring_prep_write(sqe, 0, scsi_get_out_buffer(cmd), scsi_get_out_length(cmd), cmd->offset);
 	set_cmd_async(cmd);
 
 	info->npending++;
@@ -152,11 +170,12 @@ static int queue_sync(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
 
 	if (cmd->scb[0] == SYNCHRONIZE_CACHE_16) {
 		sqe->off = cmd->offset;
-		sqe->len =scsi_get_in_length(cmd);
+		sqe->len = scsi_get_in_length(cmd);
 	}
+	io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
 	io_uring_sqe_set_data(sqe, cmd);
 	printf("d: fdatasync offset %llu len %u\n", sqe->off, sqe->len);
-	io_uring_prep_fsync(sqe, cmd->dev->fd, IORING_FSYNC_DATASYNC);
+	io_uring_prep_fsync(sqe, 0, IORING_FSYNC_DATASYNC);
 	set_cmd_async(cmd);
 
 	info->npending++;
@@ -170,16 +189,12 @@ static int queue_unmap(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
 
 	if (length < 8)
 		return 0;
-	
-	while (info->npending >= info->iodepth) {
-		bs_io_uring_get_completions_helper(info);
+
+	struct stat st;
+	if (fstat(cmd->dev->fd, &st) < 0) {
+		printf("fstat fail\n");
+		return -1;
 	}
-	
-	struct io_uring_sqe *sqe;
-	sqe = io_uring_get_sqe(&info->ring);
-    if (!sqe) {
-        return 1;
-    }
 
 	length -= 8;
 	tmpbuf += 8;
@@ -192,18 +207,46 @@ static int queue_unmap(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
 		tl = tl << cmd->dev->blk_shift;
 
 		if (offset + tl > cmd->dev->size) {
-			eprintf("UNMAP beyond EOF\n");
+			printf("e: UNMAP beyond EOF\n");
 			cmd_error_sense(cmd, ILLEGAL_REQUEST,
 					ASC_LBA_OUT_OF_RANGE);
 			break;
 		}
 
 		if (tl > 0) {
-			io_uring_sqe_set_data(sqe, cmd);
 			printf("d: unmap offset %lu length %u\n", offset, tl);
-			io_uring_prep_fallocate(sqe, cmd->dev->fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, tl);
-			set_cmd_async(cmd);
-			info->npending++;
+
+			if (S_ISREG(st.st_mode)) {
+			#ifdef FALLOC_FL_PUNCH_HOLE
+				while (info->npending >= info->iodepth) {
+					bs_io_uring_get_completions_helper(info);
+				}
+				struct io_uring_sqe *sqe;
+				sqe = io_uring_get_sqe(&info->ring);
+				if (!sqe) {
+					return 1;
+				}
+				printf("d: sending fallocate\n");
+				io_uring_sqe_set_flags(sqe, IOSQE_FIXED_FILE);
+				io_uring_sqe_set_data(sqe, cmd);
+				io_uring_prep_fallocate(sqe, 0, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, tl);
+				set_cmd_async(cmd);
+				info->npending++;
+			#endif
+			} else if (S_ISBLK(st.st_mode)) {
+			#ifdef BLKDISCARD
+				// We have to send a sync request here
+				uint64_t range[] = { offset, tl };
+				printf("d: sending BLKDISCARD o: %lu l: %lu\n", range[0], range[1]);
+				int ret = ioctl(cmd->dev->fd, BLKDISCARD, &range);
+				if (ret) {
+					printf("e: BLKDISCARD got code %d %s\n", ret, strerror(-ret));
+					return ret;
+				}
+			#endif
+			} else {
+				return -1;
+			}
 		}
 
 		length -= 16;
@@ -262,7 +305,6 @@ static int bs_io_uring_cmd_submit(struct scsi_cmd *cmd)
 		printf("d: WRITE_SAME not yet supported for IO_URING backend.\n");
 		ret = -1;
 		break;
-
 	default:
 		printf("d: skipped cmd:%p op:%x\n", cmd, scsi_op);
 		ret = 0;
@@ -282,13 +324,13 @@ static int bs_io_uring_open(struct scsi_lu *lu, char *path, int *fd, uint64_t *s
 {
 	struct bs_io_uring_info *info = BS_IO_URING_I(lu);
 	struct io_uring_params params;
-	int ret, afd;
+	int ret;
 	uint32_t blksize = 0;
 
 	memset(&params, 0, sizeof(params));
 	params.flags |= IORING_SETUP_SQPOLL;
-    params.sq_thread_idle = 2000;
-	
+    params.sq_thread_idle = 5000;
+
 	printf("e: create io_uring context for tgt:%d lun:%"PRId64 ", max iodepth:%d\n",
 		info->lu->tgt->tid, info->lu->lun, info->iodepth);
 
@@ -298,7 +340,7 @@ static int bs_io_uring_open(struct scsi_lu *lu, char *path, int *fd, uint64_t *s
 		return ret;
 	}
 
-	afd = eventfd(0, O_NONBLOCK);
+	int afd = eventfd(0, O_NONBLOCK);
 	if (afd < 0) {
 		eprintf("failed to create eventfd for tgt:%d lun:%"PRId64 ", %m\n",
 			info->lu->tgt->tid, info->lu->lun);

--- a/usr/bs_io_uring.c
+++ b/usr/bs_io_uring.c
@@ -93,8 +93,7 @@ retry_read:
 				goto retry_read;
 			case EAGAIN:
 				// EAGAIN in non-blocking evt_fd means nothing is available
-				// Still we want to continue in case some accounting error came up
-				break;
+				return;
 			default:
 				eprintf("failed to read IO_URING completions, %m\n");
 				return;

--- a/usr/bs_io_uring.c
+++ b/usr/bs_io_uring.c
@@ -44,7 +44,7 @@
 #include "scsi.h"
 #include <linux/time_types.h>
 
-#define IO_URING_MAX_IODEPTH 1024
+#define IO_URING_MAX_IODEPTH 1024*16
 
 enum unmap_mode {
 	UNMAP_MODE_BLKDISCARD,
@@ -244,7 +244,7 @@ static int queue_unmap(struct bs_io_uring_info *info, struct scsi_cmd *cmd) {
 					#endif
 					break;
 				default:
-					printf("Ignoring discard request\n");
+					eprintf("Ignoring UNMAP request\n");
 					break;
 			}
 		}


### PR DESCRIPTION
This PR adds a new backend using `io_uring` with the `liburing` library, supporting both file and block device backends.

I've been running this at home for a few months without issue, and figured it's about time I open a PR to bring it into upstream.

This backend supports WRITE, READ, SYNCHRONIZE_CACHE, and UNMAP operations

UNMAP is handled a bit special, since we can receive multiple in a single request, and need to perform a different action depending on if the backing device is a block device or regular file.
 * For regular files, we submit a group of linked fallocate SQE's with FALLOC_FL_PUNCH_HOLE and FALLOC_FL_KEEP_SIZE.
 * For devices, we need to perform synchonous BLKDISCARD requests. Once https://patchwork.kernel.org/project/io-uring/patch/a672ddb6-a141-47a5-b7f4-f992b4dcbb88@kernel.dk/ hits stable we can perform DISCARD requests in `io_uring`, but we still need to wait for that to make it into the stable kernel, and for liburing to be updated.