### PR TITLE
Remove ua sense in recovery session

### DIFF
--- a/usr/target.c
+++ b/usr/target.c
@@ -283,7 +283,6 @@ int lu_prevent_removal(struct scsi_lu *lu)
 
 int it_nexus_create(int tid, uint64_t itn_id, int host_no, char *info)
 {
-	int ret;
 	struct target *target;
 	struct it_nexus *itn;
 	struct scsi_lu *lu;
@@ -320,12 +319,6 @@ int it_nexus_create(int tid, uint64_t itn_id, int host_no, char *info)
 		itn_lu->lu = lu;
 		itn_lu->itn_id = itn_id;
 		INIT_LIST_HEAD(&itn_lu->pending_ua_sense_list);
-
-		ret = ua_sense_add(itn_lu, ASC_POWERON_RESET);
-		if (ret) {
-			free(itn_lu);
-			goto out;
-		}
 
 		list_add_tail(&itn_lu->lu_itl_info_siblings,
 			      &lu->lu_itl_info_list);


### PR DESCRIPTION
When iscsi initiator ping(noop out) failed, linux kernel will stop_conn and recover session. But value of `expecting_cc_ua` in struct scsi_device always keep 0, because of stop_conn do not wakes up SCSI EH. SCSI module only set `expecting_cc_ua = 1` in SCSI EH like the figure below.
![image](https://github.com/user-attachments/assets/d828fbcb-e2ed-4752-9c7c-adfeb1b81563)

After session recovery, tgt set the ua sense(ASC_POWERON_RESET) to pending_ua_sense_list of lun. First scmd request will get the ua sense and response with SAM_STAT_CHECK_CONDITION status, SCSI module will return IO-error to upper layer without retry. 
According to linux kernel code `scsi_done --> scsi_complete --> scsi_decide_disposition --> scsi_check_sense`, if **expecting_cc_ua = 0**, scmd response with ASC_POWERON_RESET(ua sense) do not return NEEDS_RETRY.
![image](https://github.com/user-attachments/assets/76397211-d9bc-45ea-953b-3445609a92cd)

In addition, tgt has setted ASC_POWERON_RESET ua sense for LOGICAL_UNIT_RESET and CLEAR_TASK_SET device reset operation (in target_mgmt_request funtion). 
