### PR TITLE
Remove ua sense in recovery session

### DIFF
--- a/usr/target.c
+++ b/usr/target.c
@@ -283,7 +283,6 @@ int lu_prevent_removal(struct scsi_lu *lu)
 
 int it_nexus_create(int tid, uint64_t itn_id, int host_no, char *info)
 {
-	int ret;
 	struct target *target;
 	struct it_nexus *itn;
 	struct scsi_lu *lu;
@@ -320,12 +319,6 @@ int it_nexus_create(int tid, uint64_t itn_id, int host_no, char *info)
 		itn_lu->lu = lu;
 		itn_lu->itn_id = itn_id;
 		INIT_LIST_HEAD(&itn_lu->pending_ua_sense_list);
-
-		ret = ua_sense_add(itn_lu, ASC_POWERON_RESET);
-		if (ret) {
-			free(itn_lu);
-			goto out;
-		}
 
 		list_add_tail(&itn_lu->lu_itl_info_siblings,
 			      &lu->lu_itl_info_list);


### PR DESCRIPTION
When Initiator ping(noop out) failed, linux kernel will call stop_conn and recover session. Tgt will rebuild session info(in it_nexus_create) and add the ua sense(ASC_POWERON_RESET) to pending_ua_sense_list. But, tgt Set ASC_POWERON_RESET ua sense will make scsi command fast failed, after session recovery.

After recovery, first scmd request will get the ASC_POWERON_RESET(ua sense) and response with SAM_STAT_CHECK_CONDITION status. SCSI module will return IO-error to upper layer without retry, because of `expecting_cc_ua = 0` in struct scsi_device(in kernel scsi module).

According to linux kernel code `scsi_done --> scsi_complete --> scsi_decide_disposition --> scsi_check_sense`, if **expecting_cc_ua = 0**, scmd response with ASC_POWERON_RESET(ua sense) do not NEEDS_RETRY. It make scmd fast failed, although lun(session)has recovered to normal.
![image](https://github.com/user-attachments/assets/76397211-d9bc-45ea-953b-3445609a92cd)

In addition, tgt has setted ASC_POWERON_RESET ua sense for LOGICAL_UNIT_RESET and CLEAR_TASK_SET device reset operation (in target_mgmt_request funtion). 
