### PR TITLE
Fix returning data from virtual tape when the output is bigger than t…

### DIFF
--- a/usr/bs_ssc.c
+++ b/usr/bs_ssc.c
@@ -334,7 +334,7 @@ static int resp_var_read(struct scsi_cmd *cmd, uint8_t *buf, uint32_t length,
 					     info, sizeof(info));
 
 		if (length > h->blk_sz)
-			scsi_set_in_resid_by_actual(cmd, length - h->blk_sz);
+			scsi_set_in_resid_by_actual(cmd, h->blk_sz);
 		else
 			scsi_set_in_resid_by_actual(cmd, 0);
 


### PR DESCRIPTION
…he tape block

Trivial to reproduce the bug - write a block to the virtual tape, then read it back with a blocksize bigger than the original data but less than 2x the original size. The data will be corrupted.