### PR TITLE
Better handling of config files in tgt-admin

### DIFF
--- a/scripts/tgt-admin
+++ b/scripts/tgt-admin
@@ -442,6 +442,8 @@ sub add_params {
 		return("tgtadm -C $control_port --lld $driver --op update --mode logicalunit --tid $next_tid --lun=$lun --params $param='$param_value'");
 	}
 	if ($param eq "params") {
+		$param_value =~ s/\${tid}/$next_tid/g;
+		$param_value =~ s/\${lun}/$lun/g;
 		return("tgtadm -C $control_port --lld $driver --op update --mode logicalunit --tid $next_tid --lun=$lun --params '$param_value'");
 
 	}
@@ -489,7 +491,7 @@ sub add_backing_direct {
 	}
 
 	if ($can_alloc == 1 &&
-	   ($bstype =~ "glfs" || $bstype =~ "rbd" || (-e $backing_store && ! -d $backing_store))) {
+	   ($bstype =~ "glfs" || $bstype =~ "rbd" || $backing_store =~ "^NONE:" || (-e $backing_store && ! -d $backing_store))) {
 		my @exec_commands;
 		my $device_type;
 		my $bs_type;
@@ -733,7 +735,7 @@ sub add_backing_direct {
 		if (length $bsopts) { $bsopts = "--bsopts '$bsopts'" };
 		if (length $bsoflags) { $bsoflags = "--bsoflags '$bsoflags'" };
 		if (length $block_size) { $block_size = "--blocksize '$block_size'" };
-		$backing_store = "-b '$backing_store'"
+		if ($backing_store =~ "^NONE:") { $backing_store = "" } else { $backing_store = "-b '$backing_store'" }
 		execute("tgtadm -C $control_port --lld $driver --op new --mode logicalunit --tid $next_tid --lun $lun $backing_store $device_type $bs_type $bsopts $bsoflags $block_size");
 
 		# Commands should be executed in order

--- a/scripts/tgt-admin
+++ b/scripts/tgt-admin
@@ -423,6 +423,7 @@ sub add_params {
 		}
 	}
 
+	$param_value =~ s/'/\\'/g;
 	if ($param eq "scsi_id" ||
 	    $param eq "scsi_sn" ||
 	    $param eq "vendor_id" ||
@@ -438,10 +439,10 @@ sub add_params {
 	    $param eq "optimal_xfer_gran" ||
 	    $param eq "optimal_xfer_len" ||
 	    $param eq "readonly") {
-		return("tgtadm -C $control_port --lld $driver --op update --mode logicalunit --tid $next_tid --lun=$lun --params $param=\"$param_value\"");
+		return("tgtadm -C $control_port --lld $driver --op update --mode logicalunit --tid $next_tid --lun=$lun --params $param='$param_value'");
 	}
 	if ($param eq "params") {
-		return("tgtadm -C $control_port --lld $driver --op update --mode logicalunit --tid $next_tid --lun=$lun --params \"$param_value\"");
+		return("tgtadm -C $control_port --lld $driver --op update --mode logicalunit --tid $next_tid --lun=$lun --params '$param_value'");
 
 	}
 }
@@ -720,12 +721,20 @@ sub add_backing_direct {
 			exit 1;
 		}
 		# Execute commands for a given LUN
-		if (length $device_type) { $device_type = "--device-type $device_type" };
-		if (length $bs_type) { $bs_type = "--bstype $bs_type" };
-		if (length $bsopts) { $bsopts = "--bsopts $bsopts" };
-		if (length $bsoflags) { $bsoflags = "--bsoflags $bsoflags" };
-		if (length $block_size) { $block_size = "--blocksize $block_size" };
-		execute("tgtadm -C $control_port --lld $driver --op new --mode logicalunit --tid $next_tid --lun $lun -b \"$backing_store\" $device_type $bs_type $bsopts $bsoflags $block_size");
+		# Escape any single quotes
+		$device_type =~ s/'/\\'/g;
+		$bs_type =~ s/'/\\'/g;
+		$bsopts =~ s/'/\\'/g;
+		$bsoflags =~ s/'/\\'/g;
+		$block_size =~ s/'/\\'/g;
+		$backing_store =~ s/'/\\'/g;
+		if (length $device_type) { $device_type = "--device-type '$device_type'" };
+		if (length $bs_type) { $bs_type = "--bstype '$bs_type'" };
+		if (length $bsopts) { $bsopts = "--bsopts '$bsopts'" };
+		if (length $bsoflags) { $bsoflags = "--bsoflags '$bsoflags'" };
+		if (length $block_size) { $block_size = "--blocksize '$block_size'" };
+		$backing_store = "-b '$backing_store'"
+		execute("tgtadm -C $control_port --lld $driver --op new --mode logicalunit --tid $next_tid --lun $lun $backing_store $device_type $bs_type $bsopts $bsoflags $block_size");
 
 		# Commands should be executed in order
 		my @execute_last;


### PR DESCRIPTION
There are two commits here.

The first improves the config file handling, in particular, it avoids things like executing code supplied in the config file via shell escapes.
(I don't consider this a security risk as the config files are owned by root *on debian at least) but a system that allowed other users to change these files would give a local root compromise)

The second allows a tape changer VTL to be defined in the config file (I've included my config file in the commit message)

Note that I'm including them both together because I've never tests with them separate, the first one that avoids shell escapes from the config file came about because of me wanting the second one.