### PR TITLE
Install examples in documentation directory

### DIFF
--- a/conf/Makefile
+++ b/conf/Makefile
@@ -1,4 +1,5 @@
 sysconfdir ?= /etc
+docdatadir ?= /usr/share/doc/packages
 
 EXAMPLES = targets.conf.example targets.conf.vtl.L700 targets.conf.vtl.MSL2024
 
@@ -11,9 +12,9 @@ install:
 	if [ ! -f $(DESTDIR)$(sysconfdir)/tgt/targets.conf ] ; then \
 		install -m 644 targets.conf $(DESTDIR)$(sysconfdir)/tgt ; \
 	fi
-	install -d -m 755 $(DESTDIR)$(sysconfdir)/tgt/examples
+	install -d -m 755 $(DESTDIR)$(docdatadir)/tgt/examples
 	for f in $(EXAMPLES) ; do \
-		install -m 644 examples/$$f $(DESTDIR)$(sysconfdir)/tgt/examples ;\
+		install -m 644 examples/$$f $(DESTDIR)$(docdatadir)/tgt/examples ;\
 	done
 	install -d $(DESTDIR)$(sysconfdir)/tgt/conf.d
 


### PR DESCRIPTION
Examples do not belong in /etc/tgt on many systems now, so move them to /usr/share/doc/packages/tgt, but default, though it can still be overriden and set to /etc/tgt