### PR TITLE
More updates to examples and manpage update

### DIFF
--- a/conf/examples/targets.conf.vtl.L700
+++ b/conf/examples/targets.conf.vtl.L700
@@ -88,9 +88,9 @@ default-driver iscsi
         params element_type=3,start_address=10,quantity=20,media_home=/root/tapes
         # Type 4: Add Data Transfer devices (drives)
         params element_type=4,start_address=500,quantity=3,media_home=/root/tapes
-        params element_type=4,address=500,tid=1,lun=1
-        params element_type=4,address=501,tid=1,lun=2
-        params element_type=4,address=502,tid=1,lun=3
+        params element_type=4,address=500,tid=${tid},lun=1
+        params element_type=4,address=501,tid=${tid},lun=2
+        params element_type=4,address=502,tid=${tid},lun=3
 
     </backing-store>
 </target>

--- a/doc/targets.conf.5.xml
+++ b/doc/targets.conf.5.xml
@@ -380,6 +380,11 @@
 	  <para>
 	    Pass additional parameters to tgtadm.
 	  </para>
+	  <para>
+	    Note that '${tid}' and '${lun}' can be used verbatim to refer to the
+	    tid and lun that are being configured. See targets.conf.vtl.L700 for
+	    an example.
+	  </para>
 	</listitem>
       </varlistentry>
 


### PR DESCRIPTION
Sorry, my previous PR resolved some but not all of the problems with the example. Tapes would now load with mtx but still couldn't actually be used with things like mt-st.

This fixes those issues and also updates the manpage to document the ${tid} usage in the example.

```
root@dirac:~# mtx -f /dev/sg5 status
  Storage Changer /dev/sg5:2 Drives, 8 Slots ( 0 Import/Export )
Data Transfer Element 0:Empty
Data Transfer Element 1:Empty
      Storage Element 1:Full :VolumeTag=tape001                         
      Storage Element 2:Full :VolumeTag=tape002                         
      Storage Element 3:Full :VolumeTag=tape003                         
      Storage Element 4:Empty:VolumeTag=                                
      Storage Element 5:Empty:VolumeTag=                                
      Storage Element 6:Empty:VolumeTag=                                
      Storage Element 7:Empty:VolumeTag=                                
      Storage Element 8:Empty:VolumeTag=   

root@dirac:~# mtx -f /dev/sg5 load 1 0
Loading media from Storage Element 1 into drive 0...done

root@dirac:~# mtx -f /dev/sg5 status
  Storage Changer /dev/sg5:2 Drives, 8 Slots ( 0 Import/Export )
Data Transfer Element 0:Full (Storage Element 1 Loaded):VolumeTag = tape001                         
Data Transfer Element 1:Empty
      Storage Element 1:Empty:VolumeTag=                                
      Storage Element 2:Full :VolumeTag=tape002                         
      Storage Element 3:Full :VolumeTag=tape003                         
      Storage Element 4:Empty:VolumeTag=                                
      Storage Element 5:Empty:VolumeTag=                                
      Storage Element 6:Empty:VolumeTag=                                
      Storage Element 7:Empty:VolumeTag=                                
      Storage Element 8:Empty:VolumeTag=

root@dirac:~# mt-st -f /dev/nst0 rewind

root@dirac:~# mt-st -f /dev/nst0 status
SCSI 2 tape drive:
File number=0, block number=0, partition=0.
Tape block size 0 bytes. Density code 0x0 (default).
Soft error count since last status=0
General status bits on (41010000):
 BOT ONLINE IM_REP_EN

root@dirac:~# mt-st -f /dev/nst0 eod

root@dirac:~# mt-st -f /dev/nst0 status
SCSI 2 tape drive:
File number=8388607, block number=-1, partition=0.
Tape block size 0 bytes. Density code 0x0 (default).
Soft error count since last status=0
General status bits on (9010000):
 EOD ONLINE IM_REP_EN
```